### PR TITLE
Problem: model changes in pulpcore broke FileImporter

### DIFF
--- a/pulp_file/app/models.py
+++ b/pulp_file/app/models.py
@@ -1,3 +1,4 @@
+import hashlib
 import os
 
 from collections import namedtuple
@@ -5,9 +6,14 @@ from gettext import gettext as _
 from logging import getLogger
 from urllib.parse import urlparse, urlunparse
 
+from django.core.files import File
 from django.db import models
+from django.db.utils import IntegrityError
 
-from pulpcore.plugin.models import Artifact, Content, Importer, Publisher
+from pulpcore.download import DigestValidation, DownloadError, SizeValidation
+from pulpcore.plugin.tasking import Task as current_task
+from pulpcore.plugin.models import (Artifact, Content, ContentArtifact, DeferredArtifact, Importer,
+    ProgressBar, Publisher, RepositoryContent)
 from pulpcore.plugin.changeset import (
     BatchIterator, ChangeSet, SizedIterable, RemoteContent, RemoteArtifact,
     ChangeReport, ChangeFailed)
@@ -17,11 +23,12 @@ from pulp_file.manifest import Manifest
 
 log = getLogger(__name__)
 
+BUFFER_SIZE = 65536
 
 # Changes needed.
 Delta = namedtuple('Delta', ('additions', 'removals'))
 # Natural key.
-Key = namedtuple('Key', ('path', 'digest'))
+FileTuple = namedtuple('Key', ('path', 'digest', 'size'))
 
 
 class FileContent(Content):
@@ -59,9 +66,72 @@ class FileContent(Content):
         return Key(path=self.path, digest=self.digest)
 
 
-class FileImporter(Importer):
+class PulpManifestMixin(object):
     """
-    Importer for "file" content.
+    Provides functions for working with an importer's PULP_MANIFEST.
+    """
+    def _fetch_inventory(self):
+        """
+        Fetch existing content in the repository.
+
+        Returns:
+            set: of Key.
+        """
+        inventory = set()
+        q_set = FileContent.objects.filter(repositories=self.repository)
+        q_set = q_set.only(*[f.name for f in FileContent.natural_key_fields])
+        for content in (c.cast() for c in q_set):
+            key = FileTuple(path=content.path, digest=content.digest,size=content.size)
+            inventory.add(key)
+        return inventory
+
+    def _fetch_manifest(self):
+        """
+        Fetch (download) the manifest.
+
+        Returns:
+            Manifest: The manifest.
+        """
+        parsed_url = urlparse(self.feed_url)
+        download = self.get_download(self.feed_url, os.path.basename(parsed_url.path))
+        download()
+        return Manifest(download.writer.path)
+
+    @staticmethod
+    def _find_delta(manifest, inventory, mirror=True):
+        """
+        Using the manifest and set of existing (natural) keys,
+        determine the set of content to be added and deleted from the
+        repository.  Expressed in natural key.
+        Args:
+            manifest (Manifest): The fetched manifest.
+            inventory (set): Set of existing content (natural) keys.
+            mirror (bool): Faked mirror option.
+                TODO: should be replaced with something standard.
+
+        Returns:
+            Delta: The needed changes.
+        """
+        remote = set()
+        for entry in manifest.read():
+            key = FileTuple(path=entry.path, digest=entry.digest, size=entry.size)
+            remote.add(key)
+        additions = remote - inventory
+        if mirror:
+            removals = inventory - remote
+        else:
+            removals = set()
+        return Delta(additions=additions, removals=removals)
+
+
+
+class FileImporter(Importer, PulpManifestMixin):
+    """
+    Importer for "file" content that uses ChangeSets to perform the sync.
+
+    This importer uses the ChangeSet API to download content in parallel and import into the
+    repository. Any content removed from the remote repository since the previous sync is also
+    removed from the Pulp repository.
     """
     TYPE = 'file'
 
@@ -104,59 +174,6 @@ class FileImporter(Importer):
         # On failed > 0, raise a PulpCodedException?
         # Done
 
-    def _fetch_inventory(self):
-        """
-        Fetch existing content in the repository.
-
-        Returns:
-            set: of Key.
-        """
-        inventory = set()
-        q_set = FileContent.objects.filter(repositories=self.repository)
-        q_set = q_set.only(*[f.name for f in FileContent.natural_key_fields])
-        for content in (c.cast() for c in q_set):
-            key = Key(path=content.path, digest=content.digest)
-            inventory.add(key)
-        return inventory
-
-    def _fetch_manifest(self):
-        """
-        Fetch (download) the manifest.
-
-        Returns:
-            Manifest: The manifest.
-        """
-        parsed_url = urlparse(self.feed_url)
-        download = self.get_download(self.feed_url, os.path.basename(parsed_url.path))
-        download()
-        return Manifest(download.writer.path)
-
-    @staticmethod
-    def _find_delta(manifest, inventory, mirror=True):
-        """
-        Using the manifest and set of existing (natural) keys,
-        determine the set of content to be added and deleted from the
-        repository.  Expressed in natural key.
-        Args:
-            manifest (Manifest): The fetched manifest.
-            inventory (set): Set of existing content (natural) keys.
-            mirror (bool): Faked mirror option.
-                TODO: should be replaced with something standard.
-
-        Returns:
-            Delta: The needed changes.
-        """
-        remote = set()
-        for entry in manifest.read():
-            key = Key(path=entry.path, digest=entry.digest)
-            remote.add(key)
-        additions = remote - inventory
-        if mirror:
-            removals = inventory - remote
-        else:
-            removals = set()
-        return Delta(additions=additions, removals=removals)
-
     def _build_additions(self, manifest, delta):
         """
         Generate the content to be added.
@@ -171,7 +188,7 @@ class FileImporter(Importer):
         parsed_url = urlparse(self.feed_url)
         root_dir = os.path.dirname(parsed_url.path)
         for entry in manifest.read():
-            key = Key(path=entry.path, digest=entry.digest)
+            key = FileTuple(path=entry.path, digest=entry.digest, size=entry.size)
             if key not in delta.additions:
                 continue
             path = os.path.join(root_dir, entry.path)
@@ -248,3 +265,138 @@ class FilePublisher(Publisher):
         Publish behavior for the file plugin has not yet been implemented.
         """
         raise NotImplementedError
+
+
+class BasicFileImporter(Importer, PulpManifestMixin):
+    """
+    Importer for "file" content.
+
+    This importer uses the plugin API to download content serially and import it into the
+    repository. Any content removed from the remote repository since the previous sync is also
+    removed from the Pulp repository.
+    """
+    TYPE = 'file'
+
+    def sync(self):
+        """
+        Synchronize the repository with the remote repository.
+        """
+        inventory = self._fetch_inventory()
+        manifest = self._fetch_manifest()
+        delta = self._find_delta(manifest, inventory)
+        parsed_url = urlparse(self.feed_url)
+        root_dir = os.path.dirname(parsed_url.path)
+
+        # Start reporting progress
+        if self.download_policy != self.IMMEDIATE:
+            description = _("Adding file content to the repository without downloading artifacts.")
+        else:
+            description = _("Dowloading artifacts and adding content to the repository.")
+        progress_bar = ProgressBar(message=description, total=len(delta.additions))
+        progress_bar.save()
+
+        # Add content and report progress while doing so
+        with progress_bar:
+            for entry in delta.additions:
+                path = os.path.join(root_dir, entry.path)
+                url = urlunparse(parsed_url._replace(path=path))
+                content, content_created = FileContent.objects.get_or_create(path=entry.path,
+                                                                             digest=entry.digest)
+                # Add content to the repository
+                association = RepositoryContent(
+                    repository=self.repository,
+                    content=content)
+                association.save()
+                # ContentArtifact is required for all download policies. It is used for publishing.
+                content_artifact, content_artifact_created = ContentArtifact.objects.get_or_create(
+                    content=content, relative_path=entry.path)
+                # DeferredArtifact is required for deferred download policies.
+                deferred_artifact, deferred_artifact_created = \
+                    DeferredArtifact.objects.get_or_create(
+                    url=url, importer=self, content_artifact=content_artifact, sha256=entry.digest)
+
+                if self.download_policy != self.IMMEDIATE:
+                    # Set Artifact ID if the Artifact already exists and then continue
+                    try:
+                        artifact = Artifact.objects.get(sha256=entry.digest)
+                        content_artifact.artifact = artifact
+                    except Artifact.DoesNotExist:
+                        pass
+                    content_artifact.save()
+                    # Report progress
+                    progress_bar.increment()
+                    continue
+
+                try:
+                    artifact = Artifact.objects.get(sha256=entry.digest)
+                except Artifact.DoesNotExist:
+                    download = self.get_download(url, entry.path)
+                    download.validations.append(SizeValidation(entry.size))
+                    download.validations.append(DigestValidation('sha256', entry.digest))
+                    try:
+                        download()
+                    except DownloadError as e:
+                        # Remove content and it's association with repository. Don't report
+                        # progress.
+                        association.delete()
+                        if content_created:
+                            content.delete()
+                        if deferred_artifact_created:
+                            deferred_artifact.delete()
+                        # record non-fatal exception
+                        current_task.append_non_fatal_error(e)
+                        continue
+                    else:
+                        with File(open(download.writer.path, mode='rb')) as file:
+                            checksums = self.get_checksums(file)
+                            try:
+                                artifact = Artifact(file=file, size=file.size, **checksums)
+                                artifact.save()
+                            except IntegrityError:
+                                artifact = Artifact.objects.get(sha256=checksums['sha256'])
+                            except:
+                                association.delete()
+                                if content_created:
+                                    content.delete()
+                                if deferred_artifact_created:
+                                    deferred_artifact.delete()
+                content_artifact.artifact = artifact
+                # Save ContentArtifact now that it has artifact set.
+                content_artifact.save()
+                # Report progress
+                progress_bar.increment()
+
+        # Remove content if there is any to remove
+        if delta.removals:
+            # Build a query that uniquely identifies all content that needs to be removed.
+            q = models.Q()
+            for key in delta.removals:
+                q |= models.Q(filecontent__path=key.path, filecontent__digest=key.digest)
+            q_set = self.repository.content.filter(q)
+            RepositoryContent.objects.filter(
+                repository=self.repository).filter(content=q_set).delete()
+
+    @staticmethod
+    def get_checksums(file):
+        """
+        Calculates all checksums for a file.
+
+        Args:
+            file (:class:`django.core.files.File`): open file handle
+
+        Returns:
+            dict: Dictionary where keys are checksum names and values are checksum values
+        """
+        hashers = {}
+        for algorithm in hashlib.algorithms_guaranteed:
+            hashers[algorithm] = getattr(hashlib, algorithm)()
+        while True:
+            data = file.read(BUFFER_SIZE)
+            if not data:
+                break
+            for algorithm, hasher in hashers.items():
+                hasher.update(data)
+        ret = {}
+        for algorithm, hasher in hashers.items():
+            ret[algorithm] = hasher.hexdigest()
+        return ret

--- a/pulp_file/app/serializers.py
+++ b/pulp_file/app/serializers.py
@@ -19,6 +19,12 @@ class FileImporterSerializer(platform.ImporterSerializer):
         model = models.FileImporter
 
 
+class BasicFileImporterSerializer(platform.ImporterSerializer):
+    class Meta:
+        fields = platform.ImporterSerializer.Meta.fields
+        model = models.BasicFileImporter
+
+
 class FilePublisherSerializer(platform.PublisherSerializer):
     class Meta:
         fields = platform.PublisherSerializer.Meta.fields

--- a/pulp_file/app/viewsets.py
+++ b/pulp_file/app/viewsets.py
@@ -23,6 +23,12 @@ class FileImporterViewSet(platform.ImporterViewSet):
     serializer_class = serializers.FileImporterSerializer
 
 
+class BasicFileImporterViewSet(platform.ImporterViewSet):
+    endpoint_name = 'basicfile'
+    queryset = models.BasicFileImporter.objects.all()
+    serializer_class = serializers.BasicFileImporterSerializer
+
+
 class FilePublisherViewSet(platform.PublisherViewSet):
     endpoint_name = 'file'
     queryset = models.FilePublisher.objects.all()


### PR DESCRIPTION
Solution: add BasicFileImporter that uses new models from pulpcore

Also introduces a PulpManifestMixin that provides functions for downloading a
PULP_MANIFEST and calculating a delta for repository content. This mixin is
used by both the FileImporter and BasicFileImporter.

re #2872
https://pulp.plan.io/issues/2872