### PR TITLE
Fix imports.

### DIFF
--- a/pulp_file/app/serializers.py
+++ b/pulp_file/app/serializers.py
@@ -1,25 +1,26 @@
 from rest_framework import serializers
-from pulpcore.plugin import serializers as platform
 
-from . import models
+from pulpcore.plugin.serializers import ContentSerializer, ImporterSerializer, PublisherSerializer
+
+from .models import FileContent, FileImporter, FilePublisher
 
 
-class FileContentSerializer(platform.ContentSerializer):
+class FileContentSerializer(ContentSerializer):
     path = serializers.CharField()
     digest = serializers.CharField()
 
     class Meta:
-        fields = platform.ContentSerializer.Meta.fields + ('path', 'digest')
-        model = models.FileContent
+        fields = ContentSerializer.Meta.fields + ('path', 'digest')
+        model = FileContent
 
 
-class FileImporterSerializer(platform.ImporterSerializer):
+class FileImporterSerializer(ImporterSerializer):
     class Meta:
-        fields = platform.ImporterSerializer.Meta.fields
-        model = models.FileImporter
+        fields = ImporterSerializer.Meta.fields
+        model = FileImporter
 
 
-class FilePublisherSerializer(platform.PublisherSerializer):
+class FilePublisherSerializer(PublisherSerializer):
     class Meta:
-        fields = platform.PublisherSerializer.Meta.fields
-        model = models.FilePublisher
+        fields = PublisherSerializer.Meta.fields
+        model = FilePublisher


### PR DESCRIPTION
Based on django best practices, apps should import classes from _models_, _serializers_, _viewset_ instead of the modules.  Importing the module (itself) is reserved for django imports.

This also reduces the clutter in code.