### PR TITLE
Limit FileContent api fields to relative_path and artifact

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -133,32 +133,20 @@ Create an Artifact by uploading the file to Pulp.
 Create ``file`` content from an Artifact
 -------------------------------------------
 
-Create a file with the json bellow and save it as content.json.
+Create a content unit and point it to your artifact
 
-.. code:: json
-
-    {
-      "digest": "b5bb9d8014a0f9b1d61e21e796d78dccdf1352f23cd32812f4850b878ae4944c",
-      "path": "foo.tar.gz",
-      "artifacts": {"foo.tar.gz":"http://localhost:8000/api/v3/artifacts/7d39e3f6-535a-4b6e-81e9-c83aa56aa19e/"}
-    }
-
-``$ http POST http://localhost:8000/api/v3/content/file/ < content.json``
+``$ http POST http://localhost:8000/api/v3/content/file/ relative_path=foo.tar.gz artifact="http://localhost:8000/api/v3/artifacts/7d39e3f6-535a-4b6e-81e9-c83aa56aa19e/"``
 
 .. code:: json
 
     {
         "_href": "http://localhost:8000/api/v3/content/file/a9578a5f-c59f-4920-9497-8d1699c112ff/",
-        "artifacts": {
-            "foo.tar.gz": "http://localhost:8000/api/v3/artifacts/7d39e3f6-535a-4b6e-81e9-c83aa56aa19e/"
-        },
-        "digest": "b5bb9d8014a0f9b1d61e21e796d78dccdf1352f23cd32812f4850b878ae4944c",
-        "notes": {},
-        "path": "foo.tar.gz",
+        "artifact": "http://localhost:8000/api/v3/artifacts/7d39e3f6-535a-4b6e-81e9-c83aa56aa19e/",
+        "relative_path": "foo.tar.gz",
         "type": "file"
     }
 
-``$ export CONTENT_HREF=$(http :8000/api/v3/content/file/ | jq -r '.results[] | select(.path == "foo.tar.gz") | ._href')``
+``$ export CONTENT_HREF=$(http :8000/api/v3/content/file/ | jq -r '.results[] | select(.relative_path == "foo.tar.gz") | ._href')``
 
 
 Add content to repository ``foo``

--- a/pulp_file/app/models.py
+++ b/pulp_file/app/models.py
@@ -2,7 +2,7 @@ from logging import getLogger
 
 from django.db import models
 
-from pulpcore.plugin.models import Content, Importer, Publisher
+from pulpcore.plugin.models import Content, ContentArtifact, Importer, Publisher
 
 
 log = getLogger(__name__)
@@ -16,18 +16,30 @@ class FileContent(Content):
     identified by path and SHA256 digest.
 
     Fields:
-        path (str): The file relative path.
+        relative_path (str): The file relative path.
         digest (str): The SHA256 HEX digest.
 
     """
     TYPE = 'file'
 
-    path = models.TextField(blank=False, null=False)
+    relative_path = models.TextField(blank=False, null=False)
     digest = models.TextField(blank=False, null=False)
+
+    @property
+    def artifact(self):
+        return self.artifacts.get().pk
+
+    @artifact.setter
+    def artifact(self, artifact):
+        if self.pk:
+            ca = ContentArtifact(artifact=artifact,
+                                 content=self,
+                                 relative_path=self.relative_path)
+            ca.save()
 
     class Meta:
         unique_together = (
-            'path',
+            'relative_path',
             'digest'
         )
 

--- a/pulp_file/app/serializers.py
+++ b/pulp_file/app/serializers.py
@@ -1,16 +1,23 @@
 from rest_framework import serializers
 
+from pulpcore.plugin.models import Artifact
 from pulpcore.plugin.serializers import ContentSerializer, ImporterSerializer, PublisherSerializer
 
 from .models import FileContent, FileImporter, FilePublisher
 
 
 class FileContentSerializer(ContentSerializer):
-    path = serializers.CharField()
-    digest = serializers.CharField()
+    relative_path = serializers.CharField(
+        help_text="Relative location of the file within the repository"
+    )
+    artifact = serializers.HyperlinkedRelatedField(
+        view_name='artifacts-detail',
+        help_text="Artifact file representing the physical content",
+        queryset=Artifact.objects.all()
+    )
 
     class Meta:
-        fields = ContentSerializer.Meta.fields + ('path', 'digest')
+        fields = ('_href', 'type', 'relative_path', 'artifact')
         model = FileContent
 
 

--- a/pulp_file/app/tasks/publishing.py
+++ b/pulp_file/app/tasks/publishing.py
@@ -48,9 +48,9 @@ def publish(publisher_pk, repository_pk):
             manifest = Manifest('PULP_MANIFEST')
             manifest.write(populate(publication))
             metadata = PublishedMetadata(
-                relative_path=os.path.basename(manifest.path),
+                relative_path=os.path.basename(manifest.relative_path),
                 publication=publication,
-                file=File(open(manifest.path, 'rb')))
+                file=File(open(manifest.relative_path, 'rb')))
             metadata.save()
 
     log.info(
@@ -80,9 +80,9 @@ def populate(publication):
     paths = set()
     for content in FileContent.objects.filter(
             pk__in=publication.repository_version.content).order_by('-created'):
-        if content.path in paths:
+        if content.relative_path in paths:
             continue
-        paths.add(content.path)
+        paths.add(content.relative_path)
         for content_artifact in content.contentartifact_set.all():
             artifact = find_artifact()
             published_artifact = PublishedArtifact(
@@ -91,7 +91,7 @@ def populate(publication):
                 content_artifact=content_artifact)
             published_artifact.save()
             entry = Entry(
-                path=content_artifact.relative_path,
+                relative_path=content_artifact.relative_path,
                 digest=artifact.sha256,
                 size=artifact.size)
             yield entry

--- a/pulp_file/manifest.py
+++ b/pulp_file/manifest.py
@@ -9,12 +9,12 @@ Line = namedtuple('Line', ('number', 'content'))
 class Entry:
     """
     Manifest entry.
-    Format: <path>, <digest>, <size>.
+    Format: <relative_path>, <digest>, <size>.
 
     Lines beginning with `#` are ignored.
 
     Attributes:
-        path (str): A relative path.
+        relative_path (str): A relative path.
         digest (str): The file sha256 hex digest.
         size (int): The file size in bytes.
     """
@@ -37,33 +37,33 @@ class Entry:
         if len(part) != 3:
             raise ValueError(
                 _('Error: manifest line:{n}: '
-                  'must be: <path>, <digest>, <size>').format(
+                  'must be: <relative_path>, <digest>, <size>').format(
                     n=line.number))
-        return Entry(path=part[0],
+        return Entry(relative_path=part[0],
                      digest=part[1],
                      size=int(part[2]))
 
     def __str__(self):
         """
         Returns:
-            str: format: "<path>, <digest>, <size>"
+            str: format: "<relative_path>, <digest>, <size>"
         """
         fields = [
-            self.path,
+            self.relative_path,
             self.digest,
         ]
         if isinstance(self.size, int):
             fields.append(str(self.size))
         return ', '.join(fields)
 
-    def __init__(self, path, size, digest):
+    def __init__(self, relative_path, size, digest):
         """
         Args:
-            path (str): A relative path.
+            relative_path (str): A relative path.
             digest (str): The file sha256 hex digest.
             size (int): The file size in bytes.
         """
-        self.path = path
+        self.relative_path = relative_path
         self.digest = digest
         self.size = size
 
@@ -74,24 +74,24 @@ class Manifest:
     Describes files contained within the directory.
 
     Attributes:
-        path (str): An absolute path to the manifest.
+        relative_path (str): An relative path to the manifest.
     """
 
-    def __init__(self, path):
+    def __init__(self, relative_path):
         """
         Args:
-            path (str): An absolute path to the manifest.
+            relative_path (str): An relative path to the manifest.
         """
-        self.path = path
+        self.relative_path = relative_path
 
     def read(self):
         """
-        Read the file at `path` and yield entries.
+        Read the file at `relative_path` and yield entries.
 
         Yields:
             Entry: for each line.
         """
-        with open(self.path) as fp:
+        with open(self.relative_path) as fp:
             for n, line in enumerate(fp.readlines(), 1):
                 line = line.strip()
                 if not line:
@@ -107,7 +107,7 @@ class Manifest:
         Args:
             entries (iterable): The entries to be written.
         """
-        with open(self.path, 'w+') as fp:
+        with open(self.relative_path, 'w+') as fp:
             for entry in entries:
                 line = str(entry)
                 fp.write(line)


### PR DESCRIPTION
This solves a number of issues such as differences between digest on FileContent vs Artifact.sha256, and FileContent.relative_path vs ContentArtifact.relative_path.

This also renames FileContent.path to FileContent.relative_path.

fixes #3428, #3410
https://pulp.plan.io/issues/3428
https://pulp.plan.io/issues/3410