### PR TITLE
Problem: only the latest repository version can be published

### DIFF
--- a/pulp_file/app/tasks/publishing.py
+++ b/pulp_file/app/tasks/publishing.py
@@ -23,22 +23,21 @@ log = logging.getLogger(__name__)
 
 
 @shared_task(base=UserFacingTask)
-def publish(publisher_pk, repository_pk):
+def publish(publisher_pk, repository_version_pk):
     """
     Use provided publisher to create a Publication based on a RepositoryVersion.
 
     Args:
         publisher_pk (str): Use the publish settings provided by this publisher.
-        repository_pk (str): Create a Publication from the latest version of this Repository.
+        repository_version_pk (str): Create a publication from this repository version.
     """
     publisher = FilePublisher.objects.get(pk=publisher_pk)
-    repository = Repository.objects.get(pk=repository_pk)
-    repository_version = RepositoryVersion.latest(repository)
+    repository_version = RepositoryVersion.objects.get(pk=repository_version_pk)
 
     log.info(
         _('Publishing: repository=%(repository)s, version=%(version)d, publisher=%(publisher)s'),
         {
-            'repository': repository.name,
+            'repository': repository_version.repository.name,
             'version': repository_version.number,
             'publisher': publisher.name,
         })


### PR DESCRIPTION
Solution: add ability to publish any repository version

This patch adds an optional repository_version parameter for the 'publish' endpoint of the 'file' publisher.
The REST API accepts either 'repository' or 'repository_version', but not both at the same time.

closes #3324
https://pulp.plan.io/issues/3324