### PR TITLE
Quickstart Guide instructions for importer

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -80,7 +80,7 @@ Create a repository ``foo``
 Create a new importer ``bar``
 -----------------------------
 
-``$ http POST http://localhost:8000/api/v3/importers/file/ name='bar' download_policy='immediate' sync_mode='additive' feed_url='https://repos.fedorapeople.org/pulp/pulp/demo_repos/test_file_repo/PULP_MANIFEST'``
+``$ http POST http://localhost:8000/api/v3/importers/file/ name='bar' download_policy='immediate' sync_mode='mirror' feed_url='https://repos.fedorapeople.org/pulp/pulp/demo_repos/test_file_repo/PULP_MANIFEST'``
 
 .. code:: json
 


### PR DESCRIPTION
The Quickstart Guide instructions for importer still included "additive"
and this needed to be changed to "mirror".

fixes #3469
https://pulp.plan.io/issues/3469