### PR TITLE
Add AUTHORS and COPYRIGHT files

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,0 +1,14 @@
+This is an alphabetical (by last name) list of the authors of the
+pulp_file plugin. If you submit a pull request to pulp_file and your
+name is not on this list, please add yourself.
+
+Daniel Alley (dalley@redhat.com)
+David Davis (daviddavis@redhat.com)
+Michael Hrivnak (mhrivnak@redhat.com)
+Kersom (kersom@gmail.com)
+Dennis Kliban (dkliban@redhat.com)
+Austin Macdonald (austin@redhat.com)
+Sean Myers (sean.myers@redhat.com)
+Jeff Ortel (jortel@redhat.com)
+Dana Walker (dawalker@redhat.com)
+werwty (bihan.zh@gmail.com)

--- a/COPYRIGHT
+++ b/COPYRIGHT
@@ -1,0 +1,11 @@
+Copyright © 2017 Pulp Project developers.
+
+This software is licensed to you under the GNU General Public
+License as published by the Free Software Foundation; either version
+2 of the License (GPLv2) or (at your option) any later version.
+There is NO WARRANTY for this software, express or implied,
+including the implied warranties of MERCHANTABILITY,
+NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
+have received a copy of GPLv2 along with this software; if not, see
+http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+


### PR DESCRIPTION
pulp_file was lacking AUTHORS and COPYRIGHT files, now included.

fixes #3419
https://pulp.plan.io/issues/3419