### PR TITLE
Switch to RQ

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ addons:
     postgresql: "9.5"
 services:
     - postgresql
-    - rabbitmq
+    - redis-server
 install: source .travis/install.sh
 before_script: source .travis/before_script.sh
 script: source .travis/script.sh

--- a/.travis/install.sh
+++ b/.travis/install.sh
@@ -7,6 +7,9 @@ export PULP_SMASH_PR_NUMBER=$(echo $COMMIT_MSG | grep -oP 'Required\ PR:\ https\
 
 pip install flake8 pytest
 
+# temporary workaround until a newer RQ release is available
+pip install git+https://github.com/rq/rq.git@3133d94b58e59cb86e8f4677492d48b2addcf5f8
+
 cd .. && git clone https://github.com/pulp/pulp.git
 
 if [ -z $PULP_PR_NUMBER ]; then

--- a/.travis/script.sh
+++ b/.travis/script.sh
@@ -12,18 +12,21 @@ pulp-manager migrate --noinput
 if [ $? -ne 0 ]; then
   result=1
 fi
+
+export DJANGO_SETTINGS_MODULE=pulpcore.app.settings
 pulp-manager reset-admin-password --password admin
-pulp-manager runserver >>~/django_runserver.log 2>&1 &
-celery worker -A pulpcore.tasking.celery_app:celery -n resource_manager@%h -Q resource_manager -c 1 --events --umask 18 >>~/resource_manager.log 2>&1 &
-celery worker -A pulpcore.tasking.celery_app:celery -n reserved_resource_worker_1@%h -c 1 --events --umask 18 >>~/reserved_workers-1.log 2>&1 &
+pulp-manager runserver >> ~/django_runserver.log 2>&1 &
+rq worker -n 'resource_manager@%h' -w 'pulpcore.tasking.worker.PulpWorker' >> ~/resource_manager.log 2>&1 &
+rq worker -n 'reserved_resource_worker_1@%h' -w 'pulpcore.tasking.worker.PulpWorker' >> ~/reserved_worker-1.log 2>&1 &
+
 sleep 5
 py.test -v --color=yes --pyargs pulp_smash.tests.pulp3
+
 if [ $? -ne 0 ]; then
   result=1
+  cat ~/django_runserver.log
+  cat ~/resource_manager.log
+  cat ~/reserved_worker-1.log
 fi
-
-cat ~/django_runserver.log
-cat ~/resource_manager.log
-cat ~/reserved_workers-1.log
 
 exit $result

--- a/pulp_file/app/tasks/publishing.py
+++ b/pulp_file/app/tasks/publishing.py
@@ -3,7 +3,6 @@ import os
 
 from gettext import gettext as _
 
-from celery import shared_task
 from django.core.files import File
 
 from pulpcore.plugin.models import (
@@ -12,7 +11,7 @@ from pulpcore.plugin.models import (
     PublishedArtifact,
     PublishedMetadata,
     RemoteArtifact)
-from pulpcore.plugin.tasking import UserFacingTask, WorkingDirectory
+from pulpcore.plugin.tasking import WorkingDirectory
 
 from pulp_file.app.models import FileContent, FilePublisher
 from pulp_file.manifest import Entry, Manifest
@@ -21,7 +20,6 @@ from pulp_file.manifest import Entry, Manifest
 log = logging.getLogger(__name__)
 
 
-@shared_task(base=UserFacingTask)
 def publish(publisher_pk, repository_version_pk):
     """
     Use provided publisher to create a Publication based on a RepositoryVersion.

--- a/pulp_file/app/tasks/synchronizing.py
+++ b/pulp_file/app/tasks/synchronizing.py
@@ -5,7 +5,6 @@ from collections import namedtuple
 from gettext import gettext as _
 from urllib.parse import urlparse, urlunparse
 
-from celery import shared_task
 from django.db.models import Q
 
 from pulpcore.plugin.models import Artifact, RepositoryVersion, Repository
@@ -15,7 +14,7 @@ from pulpcore.plugin.changeset import (
     PendingArtifact,
     PendingContent,
     SizedIterable)
-from pulpcore.plugin.tasking import UserFacingTask, WorkingDirectory
+from pulpcore.plugin.tasking import WorkingDirectory
 
 from pulp_file.app.models import FileContent, FileRemote
 from pulp_file.manifest import Manifest
@@ -31,7 +30,6 @@ Key = namedtuple('Key', ('relative_path', 'digest'))
 Delta = namedtuple('Delta', ('additions', 'removals'))
 
 
-@shared_task(base=UserFacingTask)
 def synchronize(remote_pk, repository_pk):
     """
     Create a new version of the repository that is synchronized with the remote


### PR DESCRIPTION
* Updates Travis to use RQ worker runners
* Remove usage of Celery
* port apply_async_with_reservation to enqueue_with_reservation

Required PR: https://github.com/PulpQE/pulp-smash/pull/960
Required PR: https://github.com/pulp/pulp/pull/3454