### PR TITLE
Don't run pulpcore smash tests for pulp-file

### DIFF
--- a/.travis/script.sh
+++ b/.travis/script.sh
@@ -17,7 +17,7 @@ pulp-manager runserver >>~/django_runserver.log 2>&1 &
 celery worker -A pulpcore.tasking.celery_app:celery -n resource_manager@%h -Q resource_manager -c 1 --events --umask 18 >>~/resource_manager.log 2>&1 &
 celery worker -A pulpcore.tasking.celery_app:celery -n reserved_resource_worker_1@%h -c 1 --events --umask 18 >>~/reserved_workers-1.log 2>&1 &
 sleep 5
-py.test -v --color=yes --pyargs pulp_smash.tests.pulp3
+py.test -v --color=yes --pyargs pulp_smash.tests.pulp3.file
 if [ $? -ne 0 ]; then
   result=1
 fi


### PR DESCRIPTION
Looking for feedback on this change. PRs shouldn't be touching pulpcore so running pulpcore tests against pulp_file seems useless.