### PR TITLE
Moving content path to namespaced location

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -135,18 +135,18 @@ Create ``file`` content from an Artifact
 
 Create a content unit and point it to your artifact
 
-``$ http POST http://localhost:8000/pulp/api/v3/content/file/ relative_path=foo.tar.gz artifact="http://localhost:8000/pulp/api/v3/artifacts/7d39e3f6-535a-4b6e-81e9-c83aa56aa19e/"``
+``$ http POST http://localhost:8000/pulp/api/v3/content/file/files/ relative_path=foo.tar.gz artifact="http://localhost:8000/pulp/api/v3/artifacts/7d39e3f6-535a-4b6e-81e9-c83aa56aa19e/"``
 
 .. code:: json
 
     {
-        "_href": "http://localhost:8000/pulp/api/v3/content/file/a9578a5f-c59f-4920-9497-8d1699c112ff/",
+        "_href": "http://localhost:8000/pulp/api/v3/content/file/files/a9578a5f-c59f-4920-9497-8d1699c112ff/",
         "artifact": "http://localhost:8000/pulp/api/v3/artifacts/7d39e3f6-535a-4b6e-81e9-c83aa56aa19e/",
         "relative_path": "foo.tar.gz",
         "type": "file"
     }
 
-``$ export CONTENT_HREF=$(http :8000/pulp/api/v3/content/file/ | jq -r '.results[] | select(.relative_path == "foo.tar.gz") | ._href')``
+``$ export CONTENT_HREF=$(http :8000/pulp/api/v3/content/file/files/ | jq -r '.results[] | select(.relative_path == "foo.tar.gz") | ._href')``
 
 
 Add content to repository ``foo``

--- a/pulp_file/app/viewsets.py
+++ b/pulp_file/app/viewsets.py
@@ -73,7 +73,7 @@ class _RepositoryPublishURLSerializer(serializers.Serializer):
 
 
 class FileContentViewSet(ContentViewSet):
-    endpoint_name = 'file'
+    endpoint_name = 'file/files'
     queryset = FileContent.objects.all()
     serializer_class = FileContentSerializer
     filter_class = FileContentFilter


### PR DESCRIPTION
Moving content path to `/content/file/files` to be consistent with docs
and other plugins (python, ansible, etc).

fixes #3601
https://pulp.plan.io/issues/3601