### PR TITLE
Detect more types of errors, and save time

### DIFF
--- a/.travis/script.sh
+++ b/.travis/script.sh
@@ -1,40 +1,41 @@
-#!/usr/bin/env sh
-set -v
+#!/usr/bin/env bash
+# coding=utf-8
+set -veuo pipefail
 
+# Lint code.
 flake8 --config flake8.cfg || exit 1
 
-result=0
-
+# Run migrations.
 export DJANGO_SETTINGS_MODULE=pulpcore.app.settings
-
 pulp-manager migrate auth --noinput
 pulp-manager makemigrations pulp_app --noinput
 pulp-manager makemigrations pulp_file
 pulp-manager migrate --noinput
-if [ $? -ne 0 ]; then
-  result=1
-fi
 
-pushd ../pulp
-coverage run manage.py test pulp_file.tests.unit
-if [ $? -ne 0 ]; then
-  result=1
-fi
-popd
+# Run unit tests.
+(cd ../pulp && coverage run manage.py test pulp_file.tests.unit)
 
+# Run functional tests.
 pulp-manager reset-admin-password --password admin
 pulp-manager runserver >> ~/django_runserver.log 2>&1 &
 rq worker -n 'resource_manager@%h' -w 'pulpcore.tasking.worker.PulpWorker' >> ~/resource_manager.log 2>&1 &
 rq worker -n 'reserved_resource_worker_1@%h' -w 'pulpcore.tasking.worker.PulpWorker' >> ~/reserved_worker-1.log 2>&1 &
-
 sleep 5
-pytest -v -r a --color=yes --pyargs pulp_file.tests.functional
+show_logs_and_return_non_zero() {
+    readonly local rc="$?"
+    cat ~/django_runserver.log
+    cat ~/resource_manager.log
+    cat ~/reserved_worker-1.log
+    return "${rc}"
+}
+pytest -v -r sx --color=yes --pyargs pulp_file.tests.functional || show_logs_and_return_non_zero
 
-if [ $? -ne 0 ]; then
-  result=1
-  cat ~/django_runserver.log
-  cat ~/resource_manager.log
-  cat ~/reserved_worker-1.log
-fi
-
-exit $result
+# Travis' scripts use unbound variables. This is problematic, because the
+# changes made to this script's environment appear to persist when Travis'
+# scripts execute. Perhaps this script is sourced by Travis? Regardless of why,
+# we need to reset the environment when this script finishes.
+#
+# We can't use `trap cleanup_function EXIT` or similar, because this script is
+# apparently sourced, and such a trap won't execute until the (buggy!) calling
+# script finishes.
+set +euo pipefail


### PR DESCRIPTION
`.travis/script.sh` runs unit tests and functional tests. Unfortunately,
it only fails when certain expressions fail. For example, if
`pulp-manager migrate --noinput` fails, then the script as a whole will
(eventually) return non-zero, but if the prior `pulp-manager
makemigrations ...` expression fails, then the script as a whole might
return zero. This means that some types of errors won't be discovered.

This script also continues executing even when failures are detected
early on. For example, if the migrations command fails, then the script
will continue on and attempt to run unit tests and functional tests.
This is a huge waste of time. Why bother running any tests at all if the
migrations have failed?

The script also catches non-zero exit codes and re-raises them as "1".
This is problematic, because a script's exact exit code can be very
meaningful, and raising "1" hides this information.

Make the script bail out with the underlying return code when most kinds
of errors are detected. This makes the test script catch more types of
errors, saves time, and provides more debugging information.