### PR TITLE
Allow custom name of the manifest when syncing and publishing

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -93,7 +93,7 @@ Create a repository ``foo``
 Create a new remote ``bar``
 ---------------------------
 
-``$ http POST http://localhost:8000/pulp/api/v3/remotes/file/ name='bar' url='https://repos.fedorapeople.org/pulp/pulp/demo_repos/test_file_repo/PULP_MANIFEST'``
+``$ http POST http://localhost:8000/pulp/api/v3/remotes/file/ name='bar' url='https://repos.fedorapeople.org/pulp/pulp/demo_repos/test_file_repo/' manifest=PULP_MANIFEST``
 
 .. code:: json
 
@@ -171,7 +171,7 @@ Add content to repository ``foo``
 Create a ``file`` Publisher
 ---------------------------
 
-``$ http POST http://localhost:8000/pulp/api/v3/publishers/file/ name=bar``
+``$ http POST http://localhost:8000/pulp/api/v3/publishers/file/ name=bar manifest=my_manifest.csv``
 
 .. code:: json
 

--- a/pulp_file/app/models.py
+++ b/pulp_file/app/models.py
@@ -56,6 +56,7 @@ class FileRemote(Remote):
     """
 
     TYPE = 'file'
+    manifest = models.TextField(blank=True, null=True)
 
 
 class FilePublisher(Publisher):
@@ -64,3 +65,4 @@ class FilePublisher(Publisher):
     """
 
     TYPE = 'file'
+    manifest = models.TextField(blank=True, null=True)

--- a/pulp_file/app/serializers.py
+++ b/pulp_file/app/serializers.py
@@ -36,8 +36,14 @@ class FileRemoteSerializer(RemoteSerializer):
     Serializer for File Remotes.
     """
 
+    manifest = serializers.CharField(
+        help_text='Name of the file manifest, the full path will be url/manifest',
+        required=False,
+        default='manifest.csv'
+    )
+
     class Meta:
-        fields = RemoteSerializer.Meta.fields
+        fields = RemoteSerializer.Meta.fields + ('manifest',)
         model = FileRemote
 
 
@@ -46,6 +52,12 @@ class FilePublisherSerializer(PublisherSerializer):
     Serializer for File Publishers.
     """
 
+    manifest = serializers.CharField(
+        help_text='Name of the file manifest, the full path will be url/manifest',
+        required=False,
+        default='manifest.csv'
+    )
+
     class Meta:
-        fields = PublisherSerializer.Meta.fields
+        fields = PublisherSerializer.Meta.fields + ('manifest',)
         model = FilePublisher

--- a/pulp_file/app/tasks/publishing.py
+++ b/pulp_file/app/tasks/publishing.py
@@ -40,7 +40,7 @@ def publish(publisher_pk, repository_version_pk):
 
     with WorkingDirectory():
         with Publication.create(repository_version, publisher) as publication:
-            manifest = Manifest('PULP_MANIFEST')
+            manifest = Manifest(publisher.manifest)
             manifest.write(populate(publication))
             metadata = PublishedMetadata(
                 relative_path=os.path.basename(manifest.relative_path),

--- a/pulp_file/app/tasks/synchronizing.py
+++ b/pulp_file/app/tasks/synchronizing.py
@@ -2,7 +2,7 @@ import logging
 import os
 
 from gettext import gettext as _
-from urllib.parse import urlparse, urlunparse
+from urllib.parse import urlparse, urlunparse, urljoin
 
 from pulpcore.plugin.models import Artifact, ProgressBar, Repository
 from pulpcore.plugin.stages import (
@@ -66,9 +66,11 @@ class FileFirstStage(Stage):
 
         """
         with ProgressBar(message='Downloading Metadata') as pb:
+            if self.remote.url[-1] != '/':
+                self.remote.url += '/'
             parsed_url = urlparse(self.remote.url)
-            root_dir = os.path.dirname(parsed_url.path)
-            downloader = self.remote.get_downloader(self.remote.url)
+            root_dir = parsed_url.path
+            downloader = self.remote.get_downloader(urljoin(self.remote.url, self.remote.manifest))
             result = await downloader.run()
             pb.increment()
 

--- a/pulp_file/tests/functional/api/test_crud_remotes.py
+++ b/pulp_file/tests/functional/api/test_crud_remotes.py
@@ -10,8 +10,8 @@ from pulp_smash.pulp3.constants import REPO_PATH
 from pulp_smash.pulp3.utils import gen_repo
 
 from pulp_file.tests.functional.constants import (
-    FILE_FIXTURE_MANIFEST_URL,
-    FILE2_FIXTURE_MANIFEST_URL,
+    FILE_FIXTURE_URL,
+    FILE2_FIXTURE_URL,
     FILE_REMOTE_PATH
 )
 from pulp_file.tests.functional.utils import gen_file_remote, skip_if
@@ -137,7 +137,7 @@ def _gen_verbose_remote():
 
     Note that 'username' and 'password' are write-only attributes.
     """
-    attrs = gen_file_remote(url=choice((FILE_FIXTURE_MANIFEST_URL, FILE2_FIXTURE_MANIFEST_URL)))
+    attrs = gen_file_remote(url=choice((FILE_FIXTURE_URL, FILE2_FIXTURE_URL)))
     attrs.update({
         'password': utils.uuid4(),
         'username': utils.uuid4(),

--- a/pulp_file/tests/functional/api/test_publish.py
+++ b/pulp_file/tests/functional/api/test_publish.py
@@ -49,6 +49,7 @@ class PublishAnyRepoVersionTestCase(unittest.TestCase):
         """
         cfg = config.get_config()
         client = api.Client(cfg, api.json_handler)
+
         body = gen_file_remote()
         remote = client.post(FILE_REMOTE_PATH, body)
         self.addCleanup(client.delete, remote['_href'])

--- a/pulp_file/tests/functional/constants.py
+++ b/pulp_file/tests/functional/constants.py
@@ -14,12 +14,11 @@ FILE_REMOTE_PATH = urljoin(BASE_REMOTE_PATH, 'file/')
 
 FILE_PUBLISHER_PATH = urljoin(BASE_PUBLISHER_PATH, 'file/')
 
+FILE_MANIFEST = 'PULP_MANIFEST'
+"""Default name of a file manifest."""
 
 FILE_FIXTURE_URL = urljoin(PULP_FIXTURES_BASE_URL, 'file/')
 """The URL to a file repository."""
-
-FILE_FIXTURE_MANIFEST_URL = urljoin(FILE_FIXTURE_URL, 'PULP_MANIFEST')
-"""The URL to a file repository manifest."""
 
 FILE_FIXTURE_COUNT = 3
 """The number of packages available at :data:`FILE_FIXTURE_URL`."""
@@ -27,14 +26,8 @@ FILE_FIXTURE_COUNT = 3
 FILE2_FIXTURE_URL = urljoin(PULP_FIXTURES_BASE_URL, 'file2/')
 """The URL to a file repository."""
 
-FILE2_FIXTURE_MANIFEST_URL = urljoin(FILE2_FIXTURE_URL, 'PULP_MANIFEST')
-"""The URL to a file repository manifest"""
-
 FILE_LARGE_FIXTURE_URL = urljoin(PULP_FIXTURES_BASE_URL, 'file-large/')
 """The URL to a file repository containing a large number of files."""
-
-FILE_LARGE_FIXTURE_MANIFEST_URL = urljoin(FILE_LARGE_FIXTURE_URL, 'PULP_MANIFEST')
-"""The URL to a file repository manifest."""
 
 FILE_URL = urljoin(FILE_FIXTURE_URL, '1.iso')
 """The URL to an ISO file at :data:`FILE_FIXTURE_URL`."""

--- a/pulp_file/tests/functional/utils.py
+++ b/pulp_file/tests/functional/utils.py
@@ -17,8 +17,9 @@ from pulp_smash.pulp3.utils import (
 
 from pulp_file.tests.functional.constants import (
     FILE_CONTENT_PATH,
-    FILE_FIXTURE_MANIFEST_URL,
-    FILE_REMOTE_PATH
+    FILE_FIXTURE_URL,
+    FILE_REMOTE_PATH,
+    FILE_MANIFEST,
 )
 
 
@@ -33,7 +34,7 @@ def populate_pulp(cfg, url=None):
         Pulp.
     """
     if url is None:
-        url = FILE_FIXTURE_MANIFEST_URL
+        url = FILE_FIXTURE_URL
 
     client = api.Client(cfg, api.json_handler)
     remote = {}
@@ -50,15 +51,19 @@ def populate_pulp(cfg, url=None):
     return client.get(FILE_CONTENT_PATH)['results']
 
 
-def gen_file_remote(url=None, **kwargs):
+def gen_file_remote(url=None, manifest=None, **kwargs):
     """Return a semi-random dict for use in creating a file Remote.
 
     :param url: The URL of an external content source.
+    :param manifest: The name of a file manifest.
     """
     if url is None:
-        url = FILE_FIXTURE_MANIFEST_URL
+        url = FILE_FIXTURE_URL
 
-    return gen_remote(url, **kwargs)
+    if manifest is None:
+        manifest = FILE_MANIFEST
+
+    return gen_remote(url, manifest=manifest, **kwargs)
 
 
 def gen_file_publisher(**kwargs):


### PR DESCRIPTION
When creating a remote user can specify his own name of the manifest.
As a path to it will be used url/manifest. For example:
```
$ http POST .../remotes/file/ 
    name=rem1 
    url=https://repos.fedorapeople.org/pulp/pulp/demo_repos/test_file_repo/
    manifest=PULP_MANIFEST
```

Same situation when creating a publisher.
For example:
```
$ http POST .../publishers/file/ 
    name=publisher1 
    manifest=my_manifest.csv
```

closes #3912, #3913
https://pulp.plan.io/issues/3912
https://pulp.plan.io/issues/3913