### PR TITLE
Run pulpcore functional tests as part of the Travis job

### DIFF
--- a/.travis/script.sh
+++ b/.travis/script.sh
@@ -30,6 +30,10 @@ show_logs_and_return_non_zero() {
 }
 pytest -v -r sx --color=yes --pyargs pulp_file.tests.functional || show_logs_and_return_non_zero
 
+# test against pulpcore as well since pulpcore has a set of tests which use pulp_file
+cd ../pulp
+pytest -v -r sx --color=yes --pyargs tests.functional.api.using_plugin || show_logs_and_return_non_zero
+
 # Travis' scripts use unbound variables. This is problematic, because the
 # changes made to this script's environment appear to persist when Travis'
 # scripts execute. Perhaps this script is sourced by Travis? Regardless of why,


### PR DESCRIPTION
Since pulpcore functional tests use pulp_file, a change in pulp_file could break these tests. Therefore, we need to run pulpcore tests against pulp_file PRs.

closes #4000
https://pulp.plan.io/issues/4000