### PR TITLE
Add test to sync an invalid feed iso

### DIFF
--- a/pulp_file/tests/functional/api/test_crud_remotes.py
+++ b/pulp_file/tests/functional/api/test_crud_remotes.py
@@ -137,7 +137,10 @@ def _gen_verbose_remote():
 
     Note that 'username' and 'password' are write-only attributes.
     """
-    attrs = gen_file_remote(url=choice((FILE_FIXTURE_MANIFEST_URL, FILE2_FIXTURE_MANIFEST_URL)))
+    attrs = gen_file_remote(url=choice((
+        FILE_FIXTURE_MANIFEST_URL,
+        FILE2_FIXTURE_MANIFEST_URL
+    )))
     attrs.update({
         'password': utils.uuid4(),
         'username': utils.uuid4(),

--- a/pulp_file/tests/functional/constants.py
+++ b/pulp_file/tests/functional/constants.py
@@ -1,4 +1,5 @@
 # coding=utf-8
+"""Constants for Pulp File plugin tests."""
 from urllib.parse import urljoin
 
 from pulp_smash.constants import PULP_FIXTURES_BASE_URL
@@ -13,7 +14,6 @@ FILE_CONTENT_PATH = urljoin(CONTENT_PATH, 'file/files/')
 FILE_REMOTE_PATH = urljoin(BASE_REMOTE_PATH, 'file/')
 
 FILE_PUBLISHER_PATH = urljoin(BASE_PUBLISHER_PATH, 'file/')
-
 
 FILE_FIXTURE_URL = urljoin(PULP_FIXTURES_BASE_URL, 'file/')
 """The URL to a file repository."""
@@ -30,10 +30,19 @@ FILE2_FIXTURE_URL = urljoin(PULP_FIXTURES_BASE_URL, 'file2/')
 FILE2_FIXTURE_MANIFEST_URL = urljoin(FILE2_FIXTURE_URL, 'PULP_MANIFEST')
 """The URL to a file repository manifest"""
 
+FILE_INVALID_FIXTURE_URL = urljoin(PULP_FIXTURES_BASE_URL, 'file-invalid/')
+"""The URL to an invalid file repository."""
+
+FILE_INVALID_MANIFEST_URL = urljoin(FILE_INVALID_FIXTURE_URL, 'PULP_MANIFEST')
+"""The URL to an invalid file repository."""
+
 FILE_LARGE_FIXTURE_URL = urljoin(PULP_FIXTURES_BASE_URL, 'file-large/')
 """The URL to a file repository containing a large number of files."""
 
-FILE_LARGE_FIXTURE_MANIFEST_URL = urljoin(FILE_LARGE_FIXTURE_URL, 'PULP_MANIFEST')
+FILE_LARGE_FIXTURE_MANIFEST_URL = urljoin(
+    FILE_LARGE_FIXTURE_URL,
+    'PULP_MANIFEST'
+)
 """The URL to a file repository manifest."""
 
 FILE_URL = urljoin(FILE_FIXTURE_URL, '1.iso')


### PR DESCRIPTION
Add a test to perform `sync` on an invalid feed iso. Refactor the
`SyncInvalidURLTestCase` to fit the new test.

Make assertions about the error message.

'[noissue]'