### PR TITLE
Remove 'null' argument from manifest model

### DIFF
--- a/pulp_file/app/models.py
+++ b/pulp_file/app/models.py
@@ -64,4 +64,4 @@ class FilePublisher(Publisher):
     """
 
     TYPE = 'file'
-    manifest = models.TextField(null=True)
+    manifest = models.TextField()


### PR DESCRIPTION
manifest cannot be ever null as is needed
for file list

https://pulp.plan.io/issues/4079

closes #4079

Signed-off-by: Pavel Picka <ppicka@redhat.com>