### PR TITLE
Adds lazy download support

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -93,7 +93,7 @@ Create a repository ``foo``
 Create a new remote ``bar``
 ---------------------------
 
-``$ http POST http://localhost:8000/pulp/api/v3/remotes/file/ name='bar' url='https://repos.fedorapeople.org/pulp/pulp/demo_repos/test_file_repo/PULP_MANIFEST'``
+``$ http POST http://localhost:8000/pulp/api/v3/remotes/file/ name='bar' url='https://repos.fedorapeople.org/pulp/pulp/demo_repos/test_file_repo/PULP_MANIFEST' policy='cache_only'``
 
 .. code:: json
 


### PR DESCRIPTION
Required PR: https://github.com/pulp/pulp/pull/3738

pulp_file now meaningfully uses the 'policy' attribute when syncing
content.

This is meant to be used with this PR:
https://github.com/pulp/pulp/pull/3738

https://pulp.plan.io/issues/4160
closes #4160