### PR TITLE
API Changes

### DIFF
--- a/.travis/install.sh
+++ b/.travis/install.sh
@@ -4,6 +4,7 @@ set -v
 export COMMIT_MSG=$(git show HEAD^2 -s)
 export PULP_PR_NUMBER=$(echo $COMMIT_MSG | grep -oP 'Required\ PR:\ https\:\/\/github\.com\/pulp\/pulp\/pull\/(\d+)' | awk -F'/' '{print $7}')
 export PULP_PLUGIN_PR_NUMBER=$(echo $COMMIT_MSG | grep -oP 'Required\ PR:\ https\:\/\/github\.com\/pulp\/pulpcore-plugin\/pull\/(\d+)' | awk -F'/' '{print $7}')
+export PULP_SMASH_PR_NUMBER=$(echo $COMMIT_MSG | grep -oP 'Required\ PR:\ https\:\/\/github\.com\/PulpQE\/pulp-smash\/pull\/(\d+)' | awk -F'/' '{print $7}')
 
 pip install -r test_requirements.txt
 
@@ -28,6 +29,16 @@ if [ -n "$PULP_PLUGIN_PR_NUMBER" ]; then
 fi
 
 pip install ./pulpcore-plugin
+
+if [ -n "$PULP_SMASH_PR_NUMBER" ]; then
+  pip uninstall -y pulp-smash
+  git clone https://github.com/PulpQE/pulp-smash.git
+  pushd pulp-smash
+  git fetch origin +refs/pull/$PULP_SMASH_PR_NUMBER/merge
+  git checkout FETCH_HEAD
+  popd
+  pip install -e ./pulp-smash
+fi
 
 cd pulp_file
 pip install -e .

--- a/pulp_file/tests/functional/api/test_publish.py
+++ b/pulp_file/tests/functional/api/test_publish.py
@@ -10,13 +10,14 @@ from pulp_smash import api, config
 from pulp_smash.pulp3.constants import REPO_PATH
 from pulp_smash.pulp3.utils import (
     gen_repo,
+    get_content,
     get_versions,
     publish,
     sync,
 )
 
 from pulp_file.tests.functional.constants import (
-    FILE_CONTENT_PATH,
+    FILE_CONTENT_NAME,
     FILE_PUBLISHER_PATH,
     FILE_REMOTE_PATH,
 )
@@ -36,6 +37,12 @@ class PublishAnyRepoVersionTestCase(unittest.TestCase):
     * `Pulp Smash #897 <https://github.com/PulpQE/pulp-smash/issues/897>`_
     """
 
+    @classmethod
+    def setUpClass(cls):
+        """Create class-wide variables."""
+        cls.cfg = config.get_config()
+        cls.client = api.Client(cls.cfg, api.json_handler)
+
     def test_all(self):
         """Test whether a particular repository version can be published.
 
@@ -50,26 +57,22 @@ class PublishAnyRepoVersionTestCase(unittest.TestCase):
         6. Assert that an exception is raised when providing two different
            repository versions to be published at same time.
         """
-        cfg = config.get_config()
-        client = api.Client(cfg, api.json_handler)
-
         body = gen_file_remote()
-        remote = client.post(FILE_REMOTE_PATH, body)
-        self.addCleanup(client.delete, remote['_href'])
+        remote = self.client.post(FILE_REMOTE_PATH, body)
+        self.addCleanup(self.client.delete, remote['_href'])
 
-        repo = client.post(REPO_PATH, gen_repo())
-        self.addCleanup(client.delete, repo['_href'])
+        repo = self.client.post(REPO_PATH, gen_repo())
+        self.addCleanup(self.client.delete, repo['_href'])
 
-        sync(cfg, remote, repo)
+        sync(self.cfg, remote, repo)
 
-        publisher = client.post(FILE_PUBLISHER_PATH, gen_file_publisher())
-        self.addCleanup(client.delete, publisher['_href'])
+        publisher = self.client.post(FILE_PUBLISHER_PATH, gen_file_publisher())
+        self.addCleanup(self.client.delete, publisher['_href'])
 
         # Step 1
-        repo = client.post(REPO_PATH, gen_repo())
-        self.addCleanup(client.delete, repo['_href'])
-        for file_content in client.get(FILE_CONTENT_PATH)['results']:
-            client.post(
+        repo = self.client.get(repo['_href'])
+        for file_content in get_content(repo)[FILE_CONTENT_NAME]:
+            self.client.post(
                 repo['_versions_href'],
                 {'add_content_units': [file_content['_href']]}
             )
@@ -77,13 +80,13 @@ class PublishAnyRepoVersionTestCase(unittest.TestCase):
         non_latest = choice(version_hrefs[:-1])
 
         # Step 2
-        publication = publish(cfg, publisher, repo)
+        publication = publish(self.cfg, publisher, repo)
 
         # Step 3
         self.assertEqual(publication['repository_version'], version_hrefs[-1])
 
         # Step 4
-        publication = publish(cfg, publisher, repo, non_latest)
+        publication = publish(self.cfg, publisher, repo, non_latest)
 
         # Step 5
         self.assertEqual(publication['repository_version'], non_latest)
@@ -92,4 +95,4 @@ class PublishAnyRepoVersionTestCase(unittest.TestCase):
         with self.assertRaises(HTTPError):
             body = {'repository': repo['_href'],
                     'repository_version': non_latest}
-            client.post(urljoin(publisher['_href'], 'publish/'), body)
+            self.client.post(urljoin(publisher['_href'], 'publish/'), body)

--- a/pulp_file/tests/functional/api/test_publish.py
+++ b/pulp_file/tests/functional/api/test_publish.py
@@ -37,12 +37,6 @@ class PublishAnyRepoVersionTestCase(unittest.TestCase):
     * `Pulp Smash #897 <https://github.com/PulpQE/pulp-smash/issues/897>`_
     """
 
-    @classmethod
-    def setUpClass(cls):
-        """Create class-wide variables."""
-        cls.cfg = config.get_config()
-        cls.client = api.Client(cls.cfg, api.json_handler)
-
     def test_all(self):
         """Test whether a particular repository version can be published.
 
@@ -57,22 +51,25 @@ class PublishAnyRepoVersionTestCase(unittest.TestCase):
         6. Assert that an exception is raised when providing two different
            repository versions to be published at same time.
         """
+        cfg = config.get_config()
+        client = api.Client(cfg, api.json_handler)
+
         body = gen_file_remote()
-        remote = self.client.post(FILE_REMOTE_PATH, body)
-        self.addCleanup(self.client.delete, remote['_href'])
+        remote = client.post(FILE_REMOTE_PATH, body)
+        self.addCleanup(client.delete, remote['_href'])
 
-        repo = self.client.post(REPO_PATH, gen_repo())
-        self.addCleanup(self.client.delete, repo['_href'])
+        repo = client.post(REPO_PATH, gen_repo())
+        self.addCleanup(client.delete, repo['_href'])
 
-        sync(self.cfg, remote, repo)
+        sync(cfg, remote, repo)
 
-        publisher = self.client.post(FILE_PUBLISHER_PATH, gen_file_publisher())
-        self.addCleanup(self.client.delete, publisher['_href'])
+        publisher = client.post(FILE_PUBLISHER_PATH, gen_file_publisher())
+        self.addCleanup(client.delete, publisher['_href'])
 
         # Step 1
-        repo = self.client.get(repo['_href'])
+        repo = client.get(repo['_href'])
         for file_content in get_content(repo)[FILE_CONTENT_NAME]:
-            self.client.post(
+            client.post(
                 repo['_versions_href'],
                 {'add_content_units': [file_content['_href']]}
             )
@@ -80,13 +77,13 @@ class PublishAnyRepoVersionTestCase(unittest.TestCase):
         non_latest = choice(version_hrefs[:-1])
 
         # Step 2
-        publication = publish(self.cfg, publisher, repo)
+        publication = publish(cfg, publisher, repo)
 
         # Step 3
         self.assertEqual(publication['repository_version'], version_hrefs[-1])
 
         # Step 4
-        publication = publish(self.cfg, publisher, repo, non_latest)
+        publication = publish(cfg, publisher, repo, non_latest)
 
         # Step 5
         self.assertEqual(publication['repository_version'], non_latest)
@@ -95,4 +92,4 @@ class PublishAnyRepoVersionTestCase(unittest.TestCase):
         with self.assertRaises(HTTPError):
             body = {'repository': repo['_href'],
                     'repository_version': non_latest}
-            self.client.post(urljoin(publisher['_href'], 'publish/'), body)
+            client.post(urljoin(publisher['_href'], 'publish/'), body)

--- a/pulp_file/tests/functional/api/test_sync.py
+++ b/pulp_file/tests/functional/api/test_sync.py
@@ -7,14 +7,13 @@ from pulp_smash.exceptions import TaskReportError
 from pulp_smash.pulp3.constants import MEDIA_PATH, REPO_PATH
 from pulp_smash.pulp3.utils import (
     gen_repo,
-    get_content,
-    get_added_content,
+    get_content_summary,
+    get_added_content_summary,
     sync,
 )
 
 from pulp_file.tests.functional.constants import (
-    FILE_CONTENT_NAME,
-    FILE_FIXTURE_COUNT,
+    FILE_FIXTURE_SUMMARY,
     FILE_INVALID_MANIFEST_URL,
     FILE_REMOTE_PATH
 )
@@ -99,8 +98,8 @@ class BasicFileSyncTestCase(unittest.TestCase):
         repo = self.client.get(repo['_href'])
 
         self.assertIsNotNone(repo['_latest_version_href'])
-        self.assertEqual(len(get_content(repo)[FILE_CONTENT_NAME]), FILE_FIXTURE_COUNT)
-        self.assertEqual(len(get_added_content(repo)[FILE_CONTENT_NAME]), FILE_FIXTURE_COUNT)
+        self.assertDictEqual(get_content_summary(repo), FILE_FIXTURE_SUMMARY)
+        self.assertDictEqual(get_added_content_summary(repo), FILE_FIXTURE_SUMMARY)
 
         # Sync the repository again.
         latest_version_href = repo['_latest_version_href']
@@ -108,8 +107,8 @@ class BasicFileSyncTestCase(unittest.TestCase):
         repo = self.client.get(repo['_href'])
 
         self.assertNotEqual(latest_version_href, repo['_latest_version_href'])
-        self.assertEqual(len(get_content(repo)[FILE_CONTENT_NAME]), FILE_FIXTURE_COUNT)
-        self.assertEqual(len(get_added_content(repo)), 0)
+        self.assertDictEqual(get_content_summary(repo), FILE_FIXTURE_SUMMARY)
+        self.assertDictEqual(get_added_content_summary(repo), {})
 
 
 class SyncInvalidTestCase(unittest.TestCase):

--- a/pulp_file/tests/functional/api/test_sync.py
+++ b/pulp_file/tests/functional/api/test_sync.py
@@ -17,10 +17,8 @@ from pulp_file.tests.functional.constants import (
     FILE_INVALID_MANIFEST_URL,
     FILE_REMOTE_PATH
 )
-from pulp_file.tests.functional.utils import (  # noqa:F401
-    gen_file_remote,
-    set_up_module as setUpModule
-)
+from pulp_file.tests.functional.utils import gen_file_remote
+from pulp_file.tests.functional.utils import set_up_module as setUpModule  # noqa:F401
 
 
 class BasicFileSyncTestCase(unittest.TestCase):

--- a/pulp_file/tests/functional/constants.py
+++ b/pulp_file/tests/functional/constants.py
@@ -12,6 +12,8 @@ from pulp_smash.pulp3.constants import (
 DOWNLOAD_POLICIES = ['streamed', 'immediate', 'on_demand']
 """Allowed download policies. Defaults to immediate."""
 
+FILE_CONTENT_NAME = 'file'
+
 FILE_CONTENT_PATH = urljoin(CONTENT_PATH, 'file/files/')
 
 FILE_REMOTE_PATH = urljoin(BASE_REMOTE_PATH, 'file/')

--- a/pulp_file/tests/functional/constants.py
+++ b/pulp_file/tests/functional/constants.py
@@ -29,6 +29,9 @@ FILE_FIXTURE_MANIFEST_URL = urljoin(FILE_FIXTURE_URL, 'PULP_MANIFEST')
 FILE_FIXTURE_COUNT = 3
 """The number of packages available at :data:`FILE_FIXTURE_URL`."""
 
+FILE_FIXTURE_SUMMARY = {FILE_CONTENT_NAME: FILE_FIXTURE_COUNT}
+"""The desired content summary after syncing :data:`FILE_FIXTURE_URL`."""
+
 FILE2_FIXTURE_URL = urljoin(PULP_FIXTURES_BASE_URL, 'file2/')
 """The URL to a file repository."""
 

--- a/pulp_file/tests/functional/utils.py
+++ b/pulp_file/tests/functional/utils.py
@@ -16,6 +16,7 @@ from pulp_smash.pulp3.utils import (
 )
 
 from pulp_file.tests.functional.constants import (
+    FILE_CONTENT_NAME,
     FILE_CONTENT_PATH,
     FILE_FIXTURE_MANIFEST_URL,
     FILE_REMOTE_PATH
@@ -69,23 +70,27 @@ def gen_file_publisher(**kwargs):
     return gen_publisher(**kwargs)
 
 
-def get_file_content_paths(repo):
-    """Return the relative path of content units present in a file repository.
-
-    :param repo: A dict of information about the repository.
-    :returns: A list with the paths of units present in a given repository.
-    """
-    # The "relative_path" is actually a file path and name
-    return [content_unit['relative_path'] for content_unit in get_content(repo)]
-
-
 def gen_file_content_attrs(artifact):
     """Generate a dict with content unit attributes.
 
-    :param: artifact: A dict of info about the artifact.
+    :param artifact: A dict of info about the artifact.
     :returns: A semi-random dict for use in creating a content unit.
     """
     return {'artifact': artifact['_href'], 'relative_path': utils.uuid4()}
+
+
+def get_file_content_paths(repo, version_href=None):
+    """Return the relative path of content units present in a file repository.
+
+    :param repo: A dict of information about the repository.
+    :param version_href: The repository version to read.
+    :returns: A list with the paths of units present in a given repository.
+    """
+    # The "relative_path" is actually a file path and name
+    return [
+        content_unit['relative_path']
+        for content_unit in get_content(repo, version_href)[FILE_CONTENT_NAME]
+    ]
 
 
 def set_up_module():


### PR DESCRIPTION
Make changes necessary to support the API changes brought over from the "single-table-content" concept, where content-in-repository-version filtering is done inside the content app instead of on special endpoints on a repository version.