### PR TITLE
Add policy to remote

### DIFF
--- a/pulp_file/tests/functional/api/test_crud_remotes.py
+++ b/pulp_file/tests/functional/api/test_crud_remotes.py
@@ -10,6 +10,7 @@ from pulp_smash.pulp3.constants import REPO_PATH
 from pulp_smash.pulp3.utils import gen_repo
 
 from pulp_file.tests.functional.constants import (
+    DOWNLOAD_POLICIES,
     FILE_FIXTURE_MANIFEST_URL,
     FILE2_FIXTURE_MANIFEST_URL,
     FILE_REMOTE_PATH
@@ -143,6 +144,7 @@ def _gen_verbose_remote():
     )))
     attrs.update({
         'password': utils.uuid4(),
+        'policy': choice(DOWNLOAD_POLICIES),
         'username': utils.uuid4(),
         'validate': choice((False, True)),
     })

--- a/pulp_file/tests/functional/constants.py
+++ b/pulp_file/tests/functional/constants.py
@@ -9,6 +9,9 @@ from pulp_smash.pulp3.constants import (
     CONTENT_PATH
 )
 
+DOWNLOAD_POLICIES = ['cache_only', 'immediate', 'on_demand']
+"""Allowed download policies. Defaults to immediate."""
+
 FILE_CONTENT_PATH = urljoin(CONTENT_PATH, 'file/files/')
 
 FILE_REMOTE_PATH = urljoin(BASE_REMOTE_PATH, 'file/')


### PR DESCRIPTION
Update a `_gen_verbose_remote` to add download policy field. Add constant
`DOWNLOAD_POLICIES`.

closes#4182
https://pulp.plan.io/issues/4182