### PR TITLE
Simplify test CRUD remotes

### DIFF
--- a/pulp_file/tests/functional/api/test_crud_remotes.py
+++ b/pulp_file/tests/functional/api/test_crud_remotes.py
@@ -6,8 +6,6 @@ import unittest
 from requests.exceptions import HTTPError
 
 from pulp_smash import api, config, utils
-from pulp_smash.pulp3.constants import REPO_PATH
-from pulp_smash.pulp3.utils import gen_repo
 
 from pulp_file.tests.functional.constants import (
     DOWNLOAD_POLICIES,
@@ -24,19 +22,10 @@ class CRUDRemotesTestCase(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
-        """Create class-wide variables.
-
-        In order to create a remote a repository has to be created first.
-        """
+        """Create class-wide variables."""
         cls.cfg = config.get_config()
         cls.client = api.Client(cls.cfg, api.json_handler)
         cls.remote = {}
-        cls.repo = cls.client.post(REPO_PATH, gen_repo())
-
-    @classmethod
-    def tearDownClass(cls):
-        """Clean class-wide variable."""
-        cls.client.delete(cls.repo['_href'])
 
     def test_01_create_remote(self):
         """Create a remote."""


### PR DESCRIPTION
Remove unnecessary repo creation as part of the CRUD remotes tests.

'[noissue]'