### PR TITLE
Modify test to use download policies from pulp-smash

### DIFF
--- a/pulp_file/tests/functional/api/test_crud_remotes.py
+++ b/pulp_file/tests/functional/api/test_crud_remotes.py
@@ -6,9 +6,9 @@ import unittest
 from requests.exceptions import HTTPError
 
 from pulp_smash import api, config, utils
+from pulp_smash.pulp3.constants import DOWNLOAD_POLICIES
 
 from pulp_file.tests.functional.constants import (
-    DOWNLOAD_POLICIES,
     FILE_FIXTURE_MANIFEST_URL,
     FILE2_FIXTURE_MANIFEST_URL,
     FILE_REMOTE_PATH

--- a/pulp_file/tests/functional/constants.py
+++ b/pulp_file/tests/functional/constants.py
@@ -9,9 +9,6 @@ from pulp_smash.pulp3.constants import (
     CONTENT_PATH
 )
 
-DOWNLOAD_POLICIES = ['streamed', 'immediate', 'on_demand']
-"""Allowed download policies. Defaults to immediate."""
-
 FILE_CONTENT_NAME = 'file'
 
 FILE_CONTENT_PATH = urljoin(CONTENT_PATH, 'file/files/')


### PR DESCRIPTION
Modify `test_crud_remotes` to use `DOWNLOAD_POLICIES` provided by
pulp-smash. `DOWNLOAD_POLICIES` is defined as tuple.

'[noissue]'