### PR TITLE
Changing relative_path and digest to CharFields

### DIFF
--- a/pulp_file/app/models.py
+++ b/pulp_file/app/models.py
@@ -22,8 +22,8 @@ class FileContent(Content):
 
     TYPE = 'file'
 
-    relative_path = models.TextField(null=False)
-    digest = models.TextField(null=False)
+    relative_path = models.CharField(max_length=255, null=False)
+    digest = models.CharField(max_length=255, null=False)
 
     @property
     def artifact(self):


### PR DESCRIPTION
The relative_path and digest fields are text fields and are used in a constraint which MySQL doesn't
support.