### PR TITLE
Rename artifact to _artifact

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -149,7 +149,7 @@ Create ``file`` content from an Artifact
 
 Create a content unit and point it to your artifact
 
-``$ http POST http://localhost:8000/pulp/api/v3/content/file/files/ relative_path=foo.tar.gz artifact="/pulp/api/v3/artifacts/1/"``
+``$ http POST http://localhost:8000/pulp/api/v3/content/file/files/ relative_path=foo.tar.gz _artifact="/pulp/api/v3/artifacts/1/"``
 
 .. code:: json
 

--- a/pulp_file/app/models.py
+++ b/pulp_file/app/models.py
@@ -26,14 +26,14 @@ class FileContent(Content):
     digest = models.TextField(null=False)
 
     @property
-    def artifact(self):
+    def _artifact(self):
         """
         Return the artifact id (there is only one for this content type).
         """
         return self._artifacts.get().pk
 
-    @artifact.setter
-    def artifact(self, artifact):
+    @_artifact.setter
+    def _artifact(self, artifact):
         """
         Set the artifact for this FileContent.
         """

--- a/pulp_file/app/serializers.py
+++ b/pulp_file/app/serializers.py
@@ -21,7 +21,7 @@ class FileContentSerializer(ContentSerializer):
     relative_path = serializers.CharField(
         help_text="Relative location of the file within the repository"
     )
-    artifact = RelatedField(
+    _artifact = RelatedField(
         view_name='artifacts-detail',
         help_text="Artifact file representing the physical content",
         queryset=Artifact.objects.all()
@@ -29,7 +29,7 @@ class FileContentSerializer(ContentSerializer):
 
     def validate(self, data):
         """Validate the FileContent data."""
-        artifact = data['artifact']
+        artifact = data['_artifact']
         content = FileContent.objects.filter(digest=artifact.sha256,
                                              relative_path=data['relative_path'])
 
@@ -37,12 +37,12 @@ class FileContentSerializer(ContentSerializer):
             raise serializers.ValidationError(_("There is already a file content with relative "
                                                 "path '{path}' and artifact '{artifact}'."
                                                 ).format(path=data["relative_path"],
-                                                         artifact=self.initial_data["artifact"]))
+                                                         artifact=self.initial_data["_artifact"]))
         return data
 
     class Meta:
         fields = tuple(set(ContentSerializer.Meta.fields) - {'_artifacts'}) + ('relative_path',
-                                                                               'artifact')
+                                                                               '_artifact')
         model = FileContent
 
 

--- a/pulp_file/app/viewsets.py
+++ b/pulp_file/app/viewsets.py
@@ -55,14 +55,15 @@ class FileContentViewSet(ContentViewSet):
         Create a new FileContent from a request.
         """
         try:
-            artifact = self.get_resource(request.data['artifact'], Artifact)
+            artifact = self.get_resource(request.data['_artifact'], Artifact)
         except KeyError:
-            raise serializers.ValidationError(detail={'artifact': _('This field is required')})
+            raise serializers.ValidationError(detail={'_artifact': _('This field is required')})
 
         serializer = self.get_serializer(data=request.data)
         serializer.is_valid(raise_exception=True)
         content = serializer.save(digest=artifact.sha256)
-        content.artifact = artifact
+
+        content._artifact = artifact
 
         headers = self.get_success_headers(request.data)
         return Response(serializer.data, status=status.HTTP_201_CREATED, headers=headers)

--- a/pulp_file/tests/functional/utils.py
+++ b/pulp_file/tests/functional/utils.py
@@ -76,7 +76,7 @@ def gen_file_content_attrs(artifact):
     :param artifact: A dict of info about the artifact.
     :returns: A semi-random dict for use in creating a content unit.
     """
-    return {'artifact': artifact['_href'], 'relative_path': utils.uuid4()}
+    return {'_artifact': artifact['_href'], 'relative_path': utils.uuid4()}
 
 
 def get_file_content_paths(repo, version_href=None):

--- a/pulp_file/tests/unit/test_serializers.py
+++ b/pulp_file/tests/unit/test_serializers.py
@@ -23,7 +23,7 @@ class TestFileContentSerializer(TestCase):
 
     def test_valid_data(self):
         """Test that the FileContentSerializer accepts valid data."""
-        data = {"artifact": "/pulp/api/v3/artifacts/{}/".format(self.artifact.pk),
+        data = {"_artifact": "/pulp/api/v3/artifacts/{}/".format(self.artifact.pk),
                 "relative_path": "foo"}
         serializer = FileContentSerializer(data=data)
         self.assertTrue(serializer.is_valid())
@@ -31,7 +31,7 @@ class TestFileContentSerializer(TestCase):
     def test_duplicate_data(self):
         """Test that the FileContentSerializer does not accept data."""
         FileContent.objects.create(relative_path="foo", digest=self.artifact.sha256)
-        data = {"artifact": "/pulp/api/v3/artifacts/{}/".format(self.artifact.pk),
+        data = {"_artifact": "/pulp/api/v3/artifacts/{}/".format(self.artifact.pk),
                 "relative_path": "foo"}
         serializer = FileContentSerializer(data=data)
         self.assertFalse(serializer.is_valid())


### PR DESCRIPTION
Renaming to '_artifact' to be clearer that artifact
is part of pulpcore. as continue for #4206 refactor.

re: #4282
https://pulp.plan.io/issues/4282

Required PR: https://github.com/pulp/pulp/pull/3843
Required PR: https://github.com/PulpQE/pulp-smash/pull/1164

Signed-off-by: Pavel Picka <ppicka@redhat.com>