### PR TITLE
Fixing bad port in the README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -214,4 +214,4 @@ Create a Distribution for the Publication
 Download ``test.iso`` from Pulp
 -------------------------------
 
-``$ http GET http://localhost:8000/pulp/content/foo/test.iso``
+``$ http GET http://localhost:8080/pulp/content/foo/test.iso``


### PR DESCRIPTION
The guide earlier says to run the content app on 8080 but then it pulls an artifact from localhost:8000.

[noissue]