### PR TITLE
Update tests structure from plugin_template

### DIFF
--- a/pulp_file/tests/functional/api/test_crud_content_unit.py
+++ b/pulp_file/tests/functional/api/test_crud_content_unit.py
@@ -8,8 +8,14 @@ from pulp_smash import api, config, utils
 from pulp_smash.pulp3.constants import ARTIFACTS_PATH
 from pulp_smash.pulp3.utils import delete_orphans
 
-from pulp_file.tests.functional.constants import FILE_CONTENT_PATH, FILE_URL
-from pulp_file.tests.functional.utils import gen_file_content_attrs, skip_if
+from pulp_file.tests.functional.constants import (
+    FILE_CONTENT_PATH,
+    FILE_URL,
+)
+from pulp_file.tests.functional.utils import (
+    gen_file_content_attrs,
+    skip_if,
+)
 from pulp_file.tests.functional.utils import set_up_module as setUpModule  # noqa:F401
 
 

--- a/pulp_file/tests/functional/api/test_crud_remotes.py
+++ b/pulp_file/tests/functional/api/test_crud_remotes.py
@@ -11,9 +11,9 @@ from pulp_smash.pulp3.constants import DOWNLOAD_POLICIES
 from pulp_file.tests.functional.constants import (
     FILE_FIXTURE_MANIFEST_URL,
     FILE2_FIXTURE_MANIFEST_URL,
-    FILE_REMOTE_PATH
+    FILE_REMOTE_PATH,
 )
-from pulp_file.tests.functional.utils import gen_file_remote, skip_if
+from pulp_file.tests.functional.utils import skip_if, gen_file_remote
 from pulp_file.tests.functional.utils import set_up_module as setUpModule  # noqa:F401
 
 
@@ -25,7 +25,6 @@ class CRUDRemotesTestCase(unittest.TestCase):
         """Create class-wide variables."""
         cls.cfg = config.get_config()
         cls.client = api.Client(cls.cfg, api.json_handler)
-        cls.remote = {}
 
     def test_01_create_remote(self):
         """Create a remote."""
@@ -111,7 +110,7 @@ class CreateRemoteNoURLTestCase(unittest.TestCase):
         * `Pulp #3395 <https://pulp.plan.io/issues/3395>`_
         * `Pulp Smash #984 <https://github.com/PulpQE/pulp-smash/issues/984>`_
         """
-        body = gen_file_remote(url=utils.uuid4())
+        body = gen_file_remote()
         del body['url']
         with self.assertRaises(HTTPError):
             api.Client(config.get_config()).post(FILE_REMOTE_PATH, body)
@@ -211,8 +210,8 @@ def _gen_verbose_remote():
     )))
     attrs.update({
         'password': utils.uuid4(),
-        'policy': choice(DOWNLOAD_POLICIES),
         'username': utils.uuid4(),
+        'policy': choice(DOWNLOAD_POLICIES),
         'validate': choice((False, True)),
     })
     return attrs

--- a/pulp_file/tests/functional/api/test_publish.py
+++ b/pulp_file/tests/functional/api/test_publish.py
@@ -44,8 +44,7 @@ class PublishAnyRepoVersionTestCase(unittest.TestCase):
         2. Create a publication by supplying the latest ``repository_version``.
         3. Assert that the publication ``repository_version`` attribute points
            to the latest repository version.
-        4. Create a publication by supplying the non-latest
-           ``repository_version``.
+        4. Create a publication by supplying the non-latest ``repository_version``.
         5. Assert that the publication ``repository_version`` attribute points
            to the supplied repository version.
         6. Assert that an exception is raised when providing two different
@@ -90,6 +89,8 @@ class PublishAnyRepoVersionTestCase(unittest.TestCase):
 
         # Step 6
         with self.assertRaises(HTTPError):
-            body = {'repository': repo['_href'],
-                    'repository_version': non_latest}
+            body = {
+                'repository': repo['_href'],
+                'repository_version': non_latest,
+            }
             client.post(urljoin(publisher['_href'], 'publish/'), body)

--- a/pulp_file/tests/functional/api/test_sync.py
+++ b/pulp_file/tests/functional/api/test_sync.py
@@ -7,15 +7,15 @@ from pulp_smash.exceptions import TaskReportError
 from pulp_smash.pulp3.constants import MEDIA_PATH, REPO_PATH
 from pulp_smash.pulp3.utils import (
     gen_repo,
-    get_content_summary,
     get_added_content_summary,
+    get_content_summary,
     sync,
 )
 
 from pulp_file.tests.functional.constants import (
     FILE_FIXTURE_SUMMARY,
     FILE_INVALID_MANIFEST_URL,
-    FILE_REMOTE_PATH
+    FILE_REMOTE_PATH,
 )
 from pulp_file.tests.functional.utils import gen_file_remote
 from pulp_file.tests.functional.utils import set_up_module as setUpModule  # noqa:F401
@@ -29,39 +29,6 @@ class BasicFileSyncTestCase(unittest.TestCase):
         """Create class-wide variables."""
         cls.cfg = config.get_config()
         cls.client = api.Client(cls.cfg, api.json_handler)
-
-    def test_file_decriptors(self):
-        """Test whether file descriptors are closed properly.
-
-        This test targets the following issue:
-
-        `Pulp #4073 <https://pulp.plan.io/issues/4073>`_
-
-        Do the following:
-
-        1. Check if 'lsof' is installed. If it is not, skip this test.
-        2. Create and sync a repo.
-        3. Run the 'lsof' command to verify that files in the
-           path ``/var/lib/pulp/`` are closed after the sync.
-        4. Assert that issued command returns `0` opened files.
-        """
-        cli_client = cli.Client(self.cfg, cli.echo_handler)
-
-        # check if 'lsof' is available
-        if cli_client.run(('which', 'lsof')).returncode != 0:
-            raise unittest.SkipTest('lsof package is not present')
-
-        repo = self.client.post(REPO_PATH, gen_repo())
-        self.addCleanup(self.client.delete, repo['_href'])
-
-        remote = self.client.post(FILE_REMOTE_PATH, gen_file_remote())
-        self.addCleanup(self.client.delete, remote['_href'])
-
-        sync(self.cfg, remote, repo)
-
-        cmd = 'lsof -t +D {}'.format(MEDIA_PATH).split()
-        response = cli_client.run(cmd).stdout
-        self.assertEqual(len(response), 0, response)
 
     def test_sync(self):
         """Sync repositories with the file plugin.
@@ -107,6 +74,39 @@ class BasicFileSyncTestCase(unittest.TestCase):
         self.assertNotEqual(latest_version_href, repo['_latest_version_href'])
         self.assertDictEqual(get_content_summary(repo), FILE_FIXTURE_SUMMARY)
         self.assertDictEqual(get_added_content_summary(repo), {})
+
+    def test_file_decriptors(self):
+        """Test whether file descriptors are closed properly.
+
+        This test targets the following issue:
+
+        `Pulp #4073 <https://pulp.plan.io/issues/4073>`_
+
+        Do the following:
+
+        1. Check if 'lsof' is installed. If it is not, skip this test.
+        2. Create and sync a repo.
+        3. Run the 'lsof' command to verify that files in the
+           path ``/var/lib/pulp/`` are closed after the sync.
+        4. Assert that issued command returns `0` opened files.
+        """
+        cli_client = cli.Client(self.cfg, cli.echo_handler)
+
+        # check if 'lsof' is available
+        if cli_client.run(('which', 'lsof')).returncode != 0:
+            raise unittest.SkipTest('lsof package is not present')
+
+        repo = self.client.post(REPO_PATH, gen_repo())
+        self.addCleanup(self.client.delete, repo['_href'])
+
+        remote = self.client.post(FILE_REMOTE_PATH, gen_file_remote())
+        self.addCleanup(self.client.delete, remote['_href'])
+
+        sync(self.cfg, remote, repo)
+
+        cmd = 'lsof -t +D {}'.format(MEDIA_PATH).split()
+        response = cli_client.run(cmd).stdout
+        self.assertEqual(len(response), 0, response)
 
 
 class SyncInvalidTestCase(unittest.TestCase):

--- a/pulp_file/tests/functional/constants.py
+++ b/pulp_file/tests/functional/constants.py
@@ -26,14 +26,22 @@ FILE_FIXTURE_MANIFEST_URL = urljoin(FILE_FIXTURE_URL, 'PULP_MANIFEST')
 FILE_FIXTURE_COUNT = 3
 """The number of packages available at :data:`FILE_FIXTURE_URL`."""
 
-FILE_FIXTURE_SUMMARY = {FILE_CONTENT_NAME: FILE_FIXTURE_COUNT}
+FILE_FIXTURE_SUMMARY = {
+    FILE_CONTENT_NAME: FILE_FIXTURE_COUNT,
+}
 """The desired content summary after syncing :data:`FILE_FIXTURE_URL`."""
+
+FILE_URL = urljoin(FILE_FIXTURE_URL, '1.iso')
+"""The URL to an ISO file at :data:`FILE_FIXTURE_URL`."""
 
 FILE2_FIXTURE_URL = urljoin(PULP_FIXTURES_BASE_URL, 'file2/')
 """The URL to a file repository."""
 
 FILE2_FIXTURE_MANIFEST_URL = urljoin(FILE2_FIXTURE_URL, 'PULP_MANIFEST')
 """The URL to a file repository manifest"""
+
+FILE2_URL = urljoin(FILE2_FIXTURE_URL, '1.iso')
+"""The URL to an ISO file at :data:`FILE2_FIXTURE_URL`."""
 
 FILE_INVALID_FIXTURE_URL = urljoin(PULP_FIXTURES_BASE_URL, 'file-invalid/')
 """The URL to an invalid file repository."""
@@ -49,9 +57,3 @@ FILE_LARGE_FIXTURE_MANIFEST_URL = urljoin(
     'PULP_MANIFEST'
 )
 """The URL to a file repository manifest."""
-
-FILE_URL = urljoin(FILE_FIXTURE_URL, '1.iso')
-"""The URL to an ISO file at :data:`FILE_FIXTURE_URL`."""
-
-FILE2_URL = urljoin(FILE2_FIXTURE_URL, '1.iso')
-"""The URL to an ISO file at :data:`FILE2_FIXTURE_URL`."""


### PR DESCRIPTION
[noissue]

This PR should only change ordering and formatting with the goal to minimize the diff of the `tests` directory wrt the corresponding one on the plugin_template.
Please compare with:
https://github.com/pulp/plugin_template/pull/34