### PR TITLE
Fix FileContent description in docs

### DIFF
--- a/pulp_file/app/models.py
+++ b/pulp_file/app/models.py
@@ -12,7 +12,7 @@ class FileContent(Content):
     """
     The "file" content type.
 
-    Content of this type represents a collection of 0 or more files uniquely
+    Content of this type represents a single file uniquely
     identified by path and SHA256 digest.
 
     Fields:


### PR DESCRIPTION
File content is always 1 file.
Fixed in models docstring.

re: #4372
https://pulp.plan.io/issues/4372
                                                                               
Required PR: https://github.com/pulp/pulpcore-plugin/pull/61

Signed-off-by: Pavel Picka <ppicka@redhat.com>