### PR TITLE
README consistency

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -103,7 +103,7 @@ Create a new remote ``bar``
         ...
     }
 
-``$ export REMOTE_HREF=$(http :8000/pulp/api/v3/remotes/file/file | jq -r '.results[] | select(.name == "bar") | ._href')``
+``$ export REMOTE_HREF=$(http :8000/pulp/api/v3/remotes/file/file/ | jq -r '.results[] | select(.name == "bar") | ._href')``
 
 Sync repository ``foo`` using remote ``bar``
 --------------------------------------------


### PR DESCRIPTION
Added '/' to the end of export command (add remote section)
as without you get error 301 and exported variable is empty.

Signed-off-by: Pavel Picka <ppicka@redhat.com>