### PR TITLE
Update 'counts' response format tests

### DIFF
--- a/pulp_file/tests/functional/constants.py
+++ b/pulp_file/tests/functional/constants.py
@@ -27,7 +27,7 @@ FILE_FIXTURE_COUNT = 3
 """The number of packages available at :data:`FILE_FIXTURE_URL`."""
 
 FILE_FIXTURE_SUMMARY = {
-    FILE_CONTENT_NAME: FILE_FIXTURE_COUNT,
+    FILE_CONTENT_NAME: {'count': FILE_FIXTURE_COUNT},
 }
 """The desired content summary after syncing :data:`FILE_FIXTURE_URL`."""
 


### PR DESCRIPTION
Due to the breaking change in the PR below, the resonse format has 
changed. No user facing features need updating, only the test assertions
change by updating the fixture data.

Required PR: https://github.com/pulp/pulpcore/pull/2

You also need the following smash PR: 

Required PR: https://github.com/PulpQE/pulp-smash/pull/1174

https://pulp.plan.io/issues/4283
re #4283