### PR TITLE
Limit the length of digest to 64 chars

### DIFF
--- a/pulp_file/app/models.py
+++ b/pulp_file/app/models.py
@@ -23,7 +23,7 @@ class FileContent(Content):
     TYPE = 'file'
 
     relative_path = models.CharField(max_length=255, null=False)
-    digest = models.CharField(max_length=255, null=False)
+    digest = models.CharField(max_length=64, null=False)
 
     class Meta:
         unique_together = (


### PR DESCRIPTION
Digests are sha256 which are 64 characters in length.

[noissue]