### PR TITLE
Update distribution creation to use task_handler

### DIFF
--- a/pulp_file/tests/functional/api/test_download_content.py
+++ b/pulp_file/tests/functional/api/test_download_content.py
@@ -105,10 +105,10 @@ class DownloadContentTestCase(unittest.TestCase):
         # Create a distribution.
         body = gen_distribution()
         body['publication'] = publication['_href']
-        response_dict = client.post(DISTRIBUTION_PATH, body)
-        dist_task = client.get(response_dict['task'])
-        distribution_href = dist_task['created_resources'][0]
-        distribution = client.get(distribution_href)
+        distribution = client.using_handler(api.task_handler).post(
+            DISTRIBUTION_PATH,
+            body
+        )
         self.addCleanup(client.delete, distribution['_href'])
 
         # Pick a file, and download it from both Pulp Fixtures…


### PR DESCRIPTION
Distribution creation it was modified to be an async task. A new
response_handler was added to pulp-smash to deal with those cases.
Update distribution creation to use this new response_handler.

'[noissue]'