### PR TITLE
Problem: travis config is using old repo name

### DIFF
--- a/.travis/publish_pulp_file_client_gem.sh
+++ b/.travis/publish_pulp_file_client_gem.sh
@@ -19,8 +19,8 @@ then
 fi
 
 cd
-git clone https://github.com/pulp/pulp-swagger-codegen.git
-cd pulp-swagger-codegen
+git clone https://github.com/pulp/pulp-openapi-generator.git
+cd pulp-openapi-generator
 
 sudo ./generate.sh pulp_file ruby $VERSION
 sudo chown -R travis:travis pulp_file-client

--- a/.travis/publish_pulp_file_client_pypi.sh
+++ b/.travis/publish_pulp_file_client_pypi.sh
@@ -18,8 +18,8 @@ then
 fi
 
 cd
-git clone https://github.com/pulp/pulp-swagger-codegen.git
-cd pulp-swagger-codegen
+git clone https://github.com/pulp/pulp-openapi-generator.git
+cd pulp-openapi-generator
 
 sudo ./generate.sh pulp_file python $VERSION
 sudo chown -R travis:travis pulp_file-client

--- a/.travis/script.sh
+++ b/.travis/script.sh
@@ -27,11 +27,11 @@ wait_for_pulp() {
 
 if [ "$TEST" = 'bindings' ]; then
   COMMIT_MSG=$(git show HEAD^2 -s)
-  export PULP_BINDINGS_PR_NUMBER=$(echo $COMMIT_MSG | grep -oP 'Required\ PR:\ https\:\/\/github\.com\/pulp\/pulp-swagger-codegen\/pull\/(\d+)' | awk -F'/' '{print $7}')
+  export PULP_BINDINGS_PR_NUMBER=$(echo $COMMIT_MSG | grep -oP 'Required\ PR:\ https\:\/\/github\.com\/pulp\/pulp-openapi-generator\/pull\/(\d+)' | awk -F'/' '{print $7}')
 
   cd ..
-  git clone https://github.com/pulp/pulp-swagger-codegen.git
-  cd pulp-swagger-codegen
+  git clone https://github.com/pulp/pulp-openapi-generator.git
+  cd pulp-openapi-generator
 
   if [ -n "$PULP_BINDINGS_PR_NUMBER" ]; then
     git fetch origin +refs/pull/$PULP_BINDINGS_PR_NUMBER/merge


### PR DESCRIPTION
Solution: update to using pulp-openapi-generator

The repo name change because the tooling it uses change.

re: #4691
https://pulp.plan.io/issues/4691