### PR TITLE
Allow policy options 'streamed' and 'on_demand'

### DIFF
--- a/CHANGES/4990.feature
+++ b/CHANGES/4990.feature
@@ -1,0 +1,1 @@
+Override the Remote's serializer to allow policy='on_demand' and policy='streamed'.

--- a/pulp_file/app/serializers.py
+++ b/pulp_file/app/serializers.py
@@ -2,6 +2,7 @@ from gettext import gettext as _
 
 from rest_framework import serializers
 
+from pulpcore.plugin import models
 from pulpcore.plugin.serializers import (
     ContentChecksumSerializer,
     DetailRelatedField,
@@ -55,6 +56,13 @@ class FileRemoteSerializer(RemoteSerializer):
     """
     Serializer for File Remotes.
     """
+
+    policy = serializers.ChoiceField(
+        help_text="The policy to use when downloading content. The possible values include: "
+                  "'immediate', 'on_demand', and 'streamed'. 'immediate' is the default.",
+        choices=models.Remote.POLICY_CHOICES,
+        default=models.Remote.IMMEDIATE
+    )
 
     class Meta:
         fields = RemoteSerializer.Meta.fields


### PR DESCRIPTION
Pulpcore recently made the RemoteSerializer validate the policy option
to only allow 'immediate'. This requires plugins that support on-demand
content to specifically allow more permissive validation.

https://pulp.plan.io/issues/4990
closes #4990