### PR TITLE
Update for pulp-smash constant name change

### DIFF
--- a/pulp_file/tests/functional/api/test_crud_remotes.py
+++ b/pulp_file/tests/functional/api/test_crud_remotes.py
@@ -6,7 +6,7 @@ import unittest
 from requests.exceptions import HTTPError
 
 from pulp_smash import api, config, utils
-from pulp_smash.pulp3.constants import DOWNLOAD_POLICIES
+from pulp_smash.pulp3.constants import ON_DEMAND_DOWNLOAD_POLICIES
 
 from pulp_file.tests.functional.constants import (
     FILE_FIXTURE_MANIFEST_URL,
@@ -188,7 +188,7 @@ class RemoteDownloadPolicyTestCase(unittest.TestCase):
         and verify the new set value.
         """
         changed_policy = choice(
-            [item for item in DOWNLOAD_POLICIES if item != 'immediate']
+            [item for item in ON_DEMAND_DOWNLOAD_POLICIES if item != 'immediate']
         )
         self.client.patch(self.remote['_href'], {'policy': changed_policy})
         self.remote.update(self.client.get(self.remote['_href']))
@@ -226,6 +226,6 @@ def _gen_verbose_remote():
     attrs.update({
         'password': utils.uuid4(),
         'username': utils.uuid4(),
-        'policy': choice(DOWNLOAD_POLICIES),
+        'policy': choice(ON_DEMAND_DOWNLOAD_POLICIES),
     })
     return attrs

--- a/pulp_file/tests/functional/api/test_download_content.py
+++ b/pulp_file/tests/functional/api/test_download_content.py
@@ -7,7 +7,7 @@ from urllib.parse import urljoin
 
 from pulp_smash import api, config, utils
 from pulp_smash.pulp3.constants import (
-    LAZY_DOWNLOAD_POLICIES,
+    ON_DEMAND_DOWNLOAD_POLICIES,
     REPO_PATH,
 )
 from pulp_smash.pulp3.utils import (
@@ -40,8 +40,8 @@ class DownloadContentTestCase(unittest.TestCase):
         """
         self.do_test('immediate')
 
-    def test_lazy_download_policies(self):
-        """Download content from Pulp. Content is synced with lazy policy.
+    def test_on_demand_download_policies(self):
+        """Download content from Pulp. Content is synced with an On-Demand policy.
 
         See :meth:`do_test`.
 
@@ -49,7 +49,7 @@ class DownloadContentTestCase(unittest.TestCase):
 
         `Pulp #4496 <https://pulp.plan.io/issues/4496>`_
         """
-        for policy in LAZY_DOWNLOAD_POLICIES:
+        for policy in ON_DEMAND_DOWNLOAD_POLICIES:
             with self.subTest(policy):
                 self.do_test(policy)
 

--- a/pulp_file/tests/functional/api/test_download_policies.py
+++ b/pulp_file/tests/functional/api/test_download_policies.py
@@ -6,7 +6,7 @@ import unittest
 from pulp_smash import api, config
 from pulp_smash.pulp3.constants import (
     ARTIFACTS_PATH,
-    LAZY_DOWNLOAD_POLICIES,
+    ON_DEMAND_DOWNLOAD_POLICIES,
     REPO_PATH,
 )
 from pulp_smash.pulp3.utils import (
@@ -195,7 +195,7 @@ class SwitchDownloadPolicyTestCase(unittest.TestCase):
         repo = client.post(REPO_PATH, gen_repo())
         self.addCleanup(client.delete, repo['_href'])
 
-        body = gen_file_remote(policy=choice(LAZY_DOWNLOAD_POLICIES))
+        body = gen_file_remote(policy=choice(ON_DEMAND_DOWNLOAD_POLICIES))
         remote = client.post(FILE_REMOTE_PATH, body)
         self.addCleanup(client.delete, remote['_href'])
 


### PR DESCRIPTION
The names were updated to replace 'lazy' with 'on demand' and also
reflect the recently changed validation in pulpcore.

Required PR: https://github.com/pulp/pulpcore/pull/199

[noissue]