### PR TITLE
3 fixes for docs/_scripts

### DIFF
--- a/docs/_scripts/add_remove.sh
+++ b/docs/_scripts/add_remove.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env sh
+#!/usr/bin/env bash
 
 echo "Kick off a task to add content to a repository, storing TASK_URL env variable"
 export TASK_URL=$(http POST $BASE_ADDR$REPO_HREF'versions/' \

--- a/docs/_scripts/artifact.sh
+++ b/docs/_scripts/artifact.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env sh
+#!/usr/bin/env bash
 
 echo "Creating a dummy file at path FILE_CONTENT to upload."
 export FILE_CONTENT=$(head /dev/urandom | tr -dc a-z | head -c10)

--- a/docs/_scripts/base.sh
+++ b/docs/_scripts/base.sh
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
 set -e
 
-echo "Setting ennvironment variables for default hostname/port for the API and the Content app"
-export BASE_ADDR=http://localhost:24817
-export CONTENT_ADDR=http://localhost:24816
+echo "Setting environment variables for default hostname/port for the API and the Content app"
+export BASE_ADDR=${BASE_ADDR:-http://localhost:24817}
+export CONTENT_ADDR=${CONTENT_ADDR:-http://localhost:24816}
 
 # Necessary for `django-admin`
 export DJANGO_SETTINGS_MODULE=pulpcore.app.settings

--- a/docs/_scripts/base.sh
+++ b/docs/_scripts/base.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env sh
+#!/usr/bin/env bash
 set -e
 
 echo "Setting ennvironment variables for default hostname/port for the API and the Content app"

--- a/docs/_scripts/content.sh
+++ b/docs/_scripts/content.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env sh
+#!/usr/bin/env bash
 
 echo 'Create File Content from the artifact and save as environment variable'
 export CONTENT_HREF=$(http POST $BASE_ADDR/pulp/api/v3/content/file/files/ \

--- a/docs/_scripts/distribution.sh
+++ b/docs/_scripts/distribution.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env sh
+#!/usr/bin/env bash
 
 export DIST_NAME=$(head /dev/urandom | tr -dc a-z | head -c5)
 export DIST_BASE_PATH=$(head /dev/urandom | tr -dc a-z | head -c5)

--- a/docs/_scripts/docs_check_sync_publish.sh
+++ b/docs/_scripts/docs_check_sync_publish.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env sh
+#!/usr/bin/env bash
 
 # This script will execute the component scripts and ensure that the documented examples
 # work as expected.

--- a/docs/_scripts/docs_check_upload_publish.sh
+++ b/docs/_scripts/docs_check_upload_publish.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env sh
+#!/usr/bin/env bash
 
 # This script will execute the component scripts and ensure that the documented examples
 # work as expected.

--- a/docs/_scripts/download_after_sync.sh
+++ b/docs/_scripts/download_after_sync.sh
@@ -3,6 +3,12 @@
 # The distribution will return a url that can be used by http clients
 echo "Setting DISTRIBUTION_BASE_URL, which is used to retrieve content from the content app."
 export DISTRIBUTION_BASE_URL=$(http $BASE_ADDR$DISTRIBUTION_HREF | jq -r '.base_url')
+# If Pulp was installed without CONTENT_HOST set, it's just the path.
+# And httpie will default to localhost:80
+if [[ "${DISTRIBUTION_BASE_URL:0:1}" = "/" ]]; then
+    DISTRIBUTION_BASE_URL=$CONTENT_ADDR$DISTRIBUTION_BASE_URL
+fi
 
 # Next we download a file from the distribution
-http -d http://$DISTRIBUTION_BASE_URL/test.iso
+# This will default to http://
+http -d $DISTRIBUTION_BASE_URL/test.iso

--- a/docs/_scripts/download_after_sync.sh
+++ b/docs/_scripts/download_after_sync.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env sh
+#!/usr/bin/env bash
 
 # The distribution will return a url that can be used by http clients
 echo "Setting DISTRIBUTION_BASE_URL, which is used to retrieve content from the content app."

--- a/docs/_scripts/download_after_upload.sh
+++ b/docs/_scripts/download_after_upload.sh
@@ -3,6 +3,12 @@
 # The distribution will return a url that can be used by http clients
 echo "Setting DISTRIBUTION_BASE_URL, which is used to retrieve content from the content app."
 export DISTRIBUTION_BASE_URL=$(http $BASE_ADDR$DISTRIBUTION_HREF | jq -r '.base_url')
+# If Pulp was installed without CONTENT_HOST set, it's just the path.
+# And httpie will default to localhost:80
+if [[ "${DISTRIBUTION_BASE_URL:0:1}" = "/" ]]; then
+    DISTRIBUTION_BASE_URL=$CONTENT_ADDR$DISTRIBUTION_BASE_URL
+fi
 
 echo "Downloading file from Distribution via the content app."
-http -d http://$DISTRIBUTION_BASE_URL/$ARTIFACT_RELATIVE_PATH
+# This will default to http://
+http -d $DISTRIBUTION_BASE_URL/$ARTIFACT_RELATIVE_PATH

--- a/docs/_scripts/download_after_upload.sh
+++ b/docs/_scripts/download_after_upload.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env sh
+#!/usr/bin/env bash
 
 # The distribution will return a url that can be used by http clients
 echo "Setting DISTRIBUTION_BASE_URL, which is used to retrieve content from the content app."

--- a/docs/_scripts/publication.sh
+++ b/docs/_scripts/publication.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env sh
+#!/usr/bin/env bash
 echo "Create a new publication specifying the repository_version."
 # Alternatively, you can specify the repository, and Pulp will assume the latest version.
 export TASK_URL=$(http POST $BASE_ADDR/pulp/api/v3/publications/file/file/ \

--- a/docs/_scripts/remote.sh
+++ b/docs/_scripts/remote.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env sh
+#!/usr/bin/env bash
 echo "Creating a remote that points to an external source of files."
 http POST $BASE_ADDR/pulp/api/v3/remotes/file/file/ \
     name='bar' \

--- a/docs/_scripts/repo.sh
+++ b/docs/_scripts/repo.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env sh
+#!/usr/bin/env bash
 export REPO_NAME=$(head /dev/urandom | tr -dc a-z | head -c5)
 
 echo "Creating a new repository named $REPO_NAME."

--- a/docs/_scripts/sync.sh
+++ b/docs/_scripts/sync.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env sh
+#!/usr/bin/env bash
 
 echo "Create a task to sync the repository using the remote."
 export TASK_URL=$(http POST $BASE_ADDR$REMOTE_HREF'sync/' repository=$REPO_HREF mirror=False \


### PR DESCRIPTION
docs/_scripts/docs_check_sync_publish.sh was tested successfully as part of the new pulp-operator CI.

See lines 679 & later:
https://travis-ci.com/pulp/pulp-operator/builds/120057404

I also tested "Only set BASE_ADDR & CONTENT_ADDR if they are unset" with the variables already set via my local Fedora bash shell.