### PR TITLE
Port performance tests

### DIFF
--- a/CHANGES/5458.misc
+++ b/CHANGES/5458.misc
@@ -1,0 +1,1 @@
+Port performance tests to pulp_file

--- a/pulp_file/manifest.py
+++ b/pulp_file/manifest.py
@@ -28,6 +28,7 @@ class Entry:
             relative_path (str): A relative path.
             digest (str): The file sha256 hex digest.
             size (int): The file size in bytes.
+
         """
         self.relative_path = relative_path
         self.digest = digest

--- a/pulp_file/tests/performance/pulpperf/interact.py
+++ b/pulp_file/tests/performance/pulpperf/interact.py
@@ -1,0 +1,78 @@
+import logging
+import requests
+import tempfile
+import time
+
+from .utils import measureit, urljoin
+
+BASE_ADDR = "http://localhost:24817"
+CONTENT_ADDR = "http://localhost:24816"
+
+
+def get(url, params={}):
+    """Wrapper around requests.get with some simplification in our case."""
+    url = BASE_ADDR + url
+
+    r = requests.get(url=url, params=params)
+    r.raise_for_status()
+    data = r.json()
+    return data
+
+
+def get_results(url, params={}):
+    """Wrapper around requests.get with some simplification in our case."""
+    out = []
+    page = 0
+    while True:
+        data = get(url, params)
+        out += data["results"]
+        page += 1
+        params["page"] = page
+        if data["next"] is None:
+            break
+    return out
+
+
+def post(url, data):
+    """Wrapper around requests.post with some simplification in our case."""
+    url = BASE_ADDR + url
+
+    r = requests.post(url=url, json=data)
+    r.raise_for_status()
+    return r.json()
+
+
+def download(base_url, file_name, file_size):
+    """Downlad file with expected size and drop it."""
+    with tempfile.TemporaryFile() as downloaded_file:
+        full_url = urljoin(CONTENT_ADDR, base_url, file_name)
+        duration, response = measureit(requests.get, full_url)
+        response.raise_for_status()
+        downloaded_file.write(response.content)
+        assert downloaded_file.tell() == file_size
+        return duration
+
+
+def wait_for_tasks(tasks, timeout=None):
+    """
+    Wait for tasks to finish.
+
+    Returns task info. If we time out, list of None is returned.
+    """
+    start = time.time()
+    out = []
+    step = 3
+    for t in tasks:
+        while True:
+            if timeout is not None:
+                now = time.time()
+                if now >= start + timeout:
+                    raise Exception("Task %s timeouted" % t)
+            response = get(t)
+            logging.debug("Task status is '%s', full response %s" % (response["state"], response))
+            if response["state"] in ("failed", "cancelled", "completed"):
+                out.append(response)
+                break
+            else:
+                time.sleep(step)
+    return out

--- a/pulp_file/tests/performance/pulpperf/reporting.py
+++ b/pulp_file/tests/performance/pulpperf/reporting.py
@@ -1,0 +1,105 @@
+import datetime
+import statistics
+
+DATETIME_FMT = "%Y-%m-%dT%H:%M:%S.%fZ"
+
+
+def parse_date_from_string(s, parse_format="%Y-%m-%dT%H:%M:%S.%fZ"):
+    """Parse string to datetime object.
+    :param s: str like '2018-11-18T21:03:32.493697Z'
+    :param parse_format: str defaults to %Y-%m-%dT%H:%M:%S.%fZ
+    :return: datetime.datetime
+    """
+    return datetime.datetime.strptime(s, parse_format)
+
+
+def tasks_table(tasks, performance_task_name):
+    """Return overview of tasks."""
+    out = []
+    for t in tasks:
+        created_at = parse_date_from_string(t["pulp_created"])
+        started_at = parse_date_from_string(t["started_at"])
+        finished_at = parse_date_from_string(t["finished_at"])
+        task_duration = finished_at - started_at
+        waiting_time = started_at - created_at
+        out.append(
+            "\n-> {task_name} => Waiting time (s): {wait} | Service time (s): {service}".format(
+                task_name=performance_task_name,
+                wait=waiting_time.total_seconds(),
+                service=task_duration.total_seconds(),
+            )
+        )
+    return "\n".join(out)
+
+
+def tasks_min_max_table(tasks):
+    """Return overview of tasks dates min and max in a table."""
+    """
+    out = "\n%11s\t%27s\t%27s\n" % ("field", "min", "max")
+    for f in ("pulp_created", "started_at", "finished_at"):
+        sample = [datetime.datetime.strptime(t[f], DATETIME_FMT) for t in tasks]
+        out += "%11s\t%s\t%s\n" % (
+            f,
+            min(sample).strftime(DATETIME_FMT),
+            max(sample).strftime(DATETIME_FMT),
+        )
+    return out
+    """
+
+
+def data_stats(data):
+    """Return basic stats fetch from provided data."""
+    return {
+        "samples": len(data),
+        "min": min(data),
+        "max": max(data),
+        "mean": statistics.mean(data),
+        "stdev": statistics.stdev(data) if len(data) > 1 else 0.0,
+    }
+
+
+def fmt_data_stats(data):
+    """
+    Format data.
+
+    https://stackoverflow.com/questions/455612/limiting-floats-to-two-decimal-points
+    """
+    return {
+        "samples": data["samples"],
+        "min": float("%.02f" % round(data["min"], 2)),
+        "max": float("%.02f" % round(data["max"], 2)),
+        "mean": float("%.02f" % round(data["mean"], 2)),
+        "stdev": float("%.02f" % round(data["stdev"], 2)),
+    }
+
+
+def tasks_waiting_time(tasks):
+    """Analyse tasks waiting time (i.e. started_at - _created)."""
+    durations = []
+    for t in tasks:
+        diff = datetime.datetime.strptime(
+            t["started_at"], DATETIME_FMT
+        ) - datetime.datetime.strptime(t["pulp_created"], DATETIME_FMT)
+        durations.append(diff.total_seconds())
+    return fmt_data_stats(data_stats(durations))
+
+
+def tasks_service_time(tasks):
+    """Analyse tasks service time (i.e. finished_at - started_at)."""
+    durations = []
+    for t in tasks:
+        diff = datetime.datetime.strptime(
+            t["finished_at"], DATETIME_FMT
+        ) - datetime.datetime.strptime(t["started_at"], DATETIME_FMT)
+        durations.append(diff.total_seconds())
+    return fmt_data_stats(data_stats(durations))
+
+
+def print_fmt_experiment_time(label, start, end):
+    """Print formatted label and experiment time."""
+    print("\n-> {} => Experiment time (s): {}".format(label, (end - start).total_seconds()))
+
+
+def report_tasks_stats(performance_task_name, tasks):
+    """Print out basic stats about received tasks."""
+    print(tasks_table(tasks, performance_task_name))

--- a/pulp_file/tests/performance/pulpperf/utils.py
+++ b/pulp_file/tests/performance/pulpperf/utils.py
@@ -1,0 +1,32 @@
+import logging
+import random
+import time
+import string
+import requests
+
+
+def get_random_string():
+    """Return random string."""
+    return "".join(random.choice(string.ascii_lowercase) for i in range(5))
+
+
+def urljoin(*args):
+    """This sucks, but works. Better ways welcome."""
+    return "/".join([i.lstrip("/").rstrip("/") for i in args])
+
+
+def measureit(func, *args, **kwargs):
+    """Measure execution time of passed function."""
+    logging.debug("Measuring duration of %s %s %s" % (func.__name__, args, kwargs))
+    before = time.clock()
+    out = func(*args, **kwargs)
+    after = time.clock()
+    return after - before, out
+
+
+def parse_pulp_manifest(url):
+    """Parse pulp manifest."""
+    response = requests.get(url)
+    response.text.split("\n")
+    data = [i.strip().split(",") for i in response.text.split("\n")]
+    return [(i[0], i[1], int(i[2])) for i in data if i != [""]]

--- a/pulp_file/tests/performance/test_nothing.py
+++ b/pulp_file/tests/performance/test_nothing.py
@@ -1,9 +1,0 @@
-import unittest
-
-
-class TestNothing(unittest.TestCase):
-    """Test Nothing (placeholder)."""
-
-    def test_nothing_at_all(self):
-        """Test that the tests are running and that's it."""
-        self.assertTrue(True)

--- a/pulp_file/tests/performance/test_performance.py
+++ b/pulp_file/tests/performance/test_performance.py
@@ -1,0 +1,293 @@
+import os
+import glob
+import errno
+import csv
+import hashlib
+import datetime
+import multiprocessing
+
+from collections import namedtuple
+from django.test import TestCase
+
+from .pulpperf import interact
+from .pulpperf import utils
+from .pulpperf import reporting
+
+DIRECTORY = "/usr/local/lib/pulp/lib/python3.7/site-packages/rest_framework/static/fixtures/"
+FILES_COUNT = 100000
+FILE_PREFIX = "a"
+FILE_SIZE = 50
+
+Args = namedtuple("Arguments", "limit processes repositories")
+
+
+class PerformanceTestCase(TestCase):
+    """
+    Test case for running performance tests.
+
+    The tests are ported from https://github.com/redhat-performance/pulpperf.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        """Create class-wide variables."""
+        super().setUpClass()
+        manifests_dumper = ManifestsDumper(DIRECTORY, FILES_COUNT, FILE_PREFIX, FILE_SIZE)
+        manifests_dumper.generate_manifests()
+
+        cls.args = Args(
+            limit=100, processes=1, repositories=["http://localhost:80/static/fixtures/"]
+        )
+        cls.data = []
+
+    @classmethod
+    def tearDownClass(cls):
+        """Clean-up generated manifests."""
+        super().tearDownClass()
+        manifests_cleaner = ManifestCleaner(DIRECTORY)
+        manifests_cleaner.clean_manifests()
+
+    def test_01_sync_repository(self):
+        """Measure time of synchronization."""
+        for r in self.args.repositories:
+            self.data.append({"remote_url": r})
+
+        for r in self.data:
+            if r["remote_url"] not in self.args.repositories:
+                continue
+            r["repository_name"] = utils.get_random_string()
+            r["repository_href"] = create_repo(r["repository_name"])
+            r["remote_name"] = utils.get_random_string()
+            r["remote_href"] = create_remote(r["remote_name"], r["remote_url"])
+
+        tasks = []
+        for r in self.data:
+            if r["remote_url"] not in self.args.repositories:
+                continue
+            task = start_sync(r["repository_href"], r["remote_href"])
+            tasks.append(task)
+
+        results = interact.wait_for_tasks(tasks)
+        reporting.report_tasks_stats("Sync tasks", results)
+
+    def test_02_resync_repository(self):
+        """Measure time of resynchronization."""
+        tasks = []
+        for r in self.data:
+            task = start_sync(r["repository_href"], r["remote_href"])
+            tasks.append(task)
+
+        results = interact.wait_for_tasks(tasks)
+        reporting.report_tasks_stats("Resync tasks", results)
+
+    def test_03_publish_repository(self):
+        """Measure time of repository publishing."""
+        tasks = []
+        for r in self.data:
+            task = create_publication(r["repository_href"])
+            tasks.append(task)
+
+        results = interact.wait_for_tasks(tasks)
+        reporting.report_tasks_stats("Publication tasks", results)
+
+        for i in range(len(results)):
+            self.data[i]["publication_href"] = results[i]["created_resources"][0]
+            self.data[i]["repository_version_href"] = interact.get(
+                self.data[i]["publication_href"]
+            )["repository_version"]
+
+        tasks = []
+        for r in self.data:
+            r["distribution_name"] = utils.get_random_string()
+            r["distribution_base_path"] = utils.get_random_string()
+            task = create_distribution(
+                r["distribution_name"], r["distribution_base_path"], r["publication_href"]
+            )
+            tasks.append(task)
+
+        results = interact.wait_for_tasks(tasks)
+        reporting.report_tasks_stats("Distribution tasks", results)
+
+        for i in range(len(results)):
+            self.data[i]["distribution_href"] = results[i]["created_resources"][0]
+            self.data[i]["download_base_url"] = interact.get(self.data[i]["distribution_href"])[
+                "base_url"
+            ]
+
+    def test_04_download_repo(self):
+        """Measure time of repository downloading."""
+        before = datetime.datetime.utcnow()
+
+        for r in self.data:
+            params = []
+            pulp_manifest = utils.parse_pulp_manifest(r["remote_url"] + "PULP_MANIFEST")
+            for f, _, s in pulp_manifest[: self.args.limit]:
+                params.append((r["download_base_url"], f, s))
+            with multiprocessing.Pool(processes=self.args.processes) as pool:
+                pool.starmap(interact.download, params)
+
+        after = datetime.datetime.utcnow()
+        reporting.print_fmt_experiment_time("Repository download", before, after)
+
+    def test_05_list_content(self):
+        """Measure time of inspecting the repository content."""
+        before = datetime.datetime.utcnow()
+
+        durations_list = []
+        for r in self.data:
+            duration, content = utils.measureit(
+                list_units_in_repo_ver, r["repository_version_href"]
+            )
+            durations_list.append(duration)
+
+            params = []
+            for c in content[: self.args.limit]:
+                url = c.get("pulp_href")
+                params.append((inspect_content, url))
+            with multiprocessing.Pool(processes=self.args.processes) as pool:
+                pool.starmap(utils.measureit, params)
+        after = datetime.datetime.utcnow()
+        reporting.print_fmt_experiment_time("Content inspection", before, after)
+
+    def test_06_repo_version(self):
+        """Measure time of repository cloning."""
+        for r in self.data:
+            r["repository_clone1_name"] = utils.get_random_string()
+            r["repository_clone1_href"] = create_repo(r["repository_clone1_name"])
+            r["repository_clone2_name"] = utils.get_random_string()
+            r["repository_clone2_href"] = create_repo(r["repository_clone2_name"])
+
+        tasks = []
+        for r in self.data:
+            task = create_repo_version_base_version(
+                r["repository_clone1_href"], r["repository_version_href"]
+            )
+            tasks.append(task)
+
+        results = interact.wait_for_tasks(tasks)
+        reporting.report_tasks_stats("Version clone with base_version tasks", results)
+
+        hrefs = [i["pulp_href"] for i in list_units_in_repo_ver(r["repository_version_href"])]
+
+        tasks = []
+        for r in self.data:
+            task = create_repo_version_add_content_units(r["repository_clone2_href"], hrefs)
+            tasks.append(task)
+
+        results = interact.wait_for_tasks(tasks)
+        reporting.report_tasks_stats("Version clone with add_content_units tasks", results)
+
+
+class ManifestsDumper:
+    """A handler which generates manifests in a current file system."""
+
+    def __init__(self, directory, files_count, file_prefix, file_size):
+        """Initialize all variables necessary for dumping manifest files."""
+        self._directory = directory
+        self._files_count = files_count
+        self._file_prefix = file_prefix
+        self._file_size = file_size
+
+    def generate_manifests(self):
+        """Generate manifests within specified directory."""
+        pulp_manifests = []
+        for i in range(FILES_COUNT):
+            pulp_manifests.append(self._create_file(i))
+        self._dump_manifest(pulp_manifests)
+
+    def _create_file(self, file_id, file_suffix=".iso"):
+        """Create a file with defined size and return info needed for PULP_MANIFEST."""
+        file_name = self._file_prefix + str(file_id) + file_suffix
+        file_path = os.path.join(self._directory, file_name)
+        file_content = self._file_prefix + str(file_id).zfill(
+            self._file_size - len(self._file_prefix)
+        )
+        file_content = file_content.encode()
+
+        assert len(file_content) == self._file_size
+
+        try:
+            os.makedirs(os.path.dirname(file_path))
+        except OSError as e:
+            if e.errno != errno.EEXIST:
+                raise
+
+        with open(file_path, "wb") as fp:
+            fp.write(file_content)
+        file_checksum = hashlib.sha256(file_content).hexdigest()
+
+        return file_name, file_checksum, self._file_size
+
+    def _dump_manifest(self, content):
+        """Dump a PULP_MANIFEST file into a specified directory."""
+        manifest_path = os.path.join(self._directory, "PULP_MANIFEST")
+        with open(manifest_path, mode="w") as fp:
+            writer = csv.writer(fp, delimiter=",", quoting=csv.QUOTE_NONE)
+            for row in content:
+                writer.writerow(row)
+
+
+class ManifestCleaner:
+    """A class responsible for cleaning all generated resources within the file system."""
+
+    def __init__(self, directory):
+        """Store a path to a directory which is going to be cleaned."""
+        self._directory = directory
+
+    def clean_manifests(self):
+        """Remove all manifests within the directory."""
+        files_pathname = os.path.join(self._directory, "*")
+        for file_path in glob.glob(files_pathname):
+            os.remove(file_path)
+
+
+def create_repo(name):
+    """Create repository"""
+    return interact.post("/pulp/api/v3/repositories/", data={"name": name})["pulp_href"]
+
+
+def create_remote(name, url):
+    """Create remote"""
+    return interact.post(
+        "/pulp/api/v3/remotes/file/file/", data={"name": name, "url": url + "PULP_MANIFEST"}
+    )["pulp_href"]
+
+
+def start_sync(repo, remote):
+    """Start sync of the remote into the repository, return task"""
+    return interact.post(remote + "sync/", data={"repository": repo, "mirror": False})["task"]
+
+
+def create_publication(repo):
+    """Start publication of the repository, return task"""
+    return interact.post("/pulp/api/v3/publications/file/file/", data={"repository": repo})["task"]
+
+
+def create_distribution(name, base_path, pub):
+    """Start distribution of the repository version, return task"""
+    return interact.post(
+        "/pulp/api/v3/distributions/file/file/",
+        data={"name": name, "base_path": base_path, "publication": pub},
+    )["task"]
+
+
+def list_units_in_repo_ver(repo_ver):
+    """List the file content with all the fields"""
+    return interact.get_results(
+        "/pulp/api/v3/content/file/files/", params={"repository_version": repo_ver}
+    )
+
+
+def inspect_content(href):
+    """Inspect a file content using href"""
+    return interact.get(href)
+
+
+def create_repo_version_base_version(repo, ver):
+    """Create repository version based on different existing version"""
+    return interact.post(repo + "versions/", data={"base_version": ver})["task"]
+
+
+def create_repo_version_add_content_units(repo, hrefs):
+    """Create repository version based on list of hrefs"""
+    return interact.post(repo + "versions/", data={"add_content_units": hrefs})["task"]


### PR DESCRIPTION
Compared to existing performance tests, fixtures are generated in
/usr/local/lib/pulp/lib/python3.7/site-packages/rest_framework/static/fixtures/.
And then available at http://localhost:80/static/fixtures/.

It order to execute these tests, it is required to define CONTENT_HOST
in /etc/pulp/settings.py.

closes #5458
https://pulp.plan.io/issues/5458