### PR TITLE
Prevent duplicate `relative_path` files

### DIFF
--- a/CHANGES/4028.bugfix
+++ b/CHANGES/4028.bugfix
@@ -1,0 +1,2 @@
+New RepositoryVersions will remove an existing unit at the same `relative_path`. This is true for
+both `sync` and `upload`, and is per Repository.

--- a/pulp_file/app/models.py
+++ b/pulp_file/app/models.py
@@ -21,6 +21,7 @@ class FileContent(Content):
     """
 
     TYPE = "file"
+    repo_key = ("relative_path",)
 
     relative_path = models.CharField(max_length=255, null=False)
     digest = models.CharField(max_length=64, null=False)

--- a/pulp_file/app/tasks/publishing.py
+++ b/pulp_file/app/tasks/publishing.py
@@ -62,13 +62,9 @@ def populate(publication):
             _artifact = RemoteArtifact.objects.filter(content_artifact=content_artifact).first()
         return _artifact
 
-    paths = set()
     for content in FileContent.objects.filter(
         pk__in=publication.repository_version.content
     ).order_by("-_created"):
-        if content.relative_path in paths:
-            continue
-        paths.add(content.relative_path)
         for content_artifact in content.contentartifact_set.all():
             artifact = find_artifact()
             entry = Entry(

--- a/pulp_file/tests/functional/constants.py
+++ b/pulp_file/tests/functional/constants.py
@@ -38,6 +38,9 @@ FILE_FIXTURE_SUMMARY = {FILE_CONTENT_NAME: FILE_FIXTURE_COUNT}
 FILE_URL = urljoin(FILE_FIXTURE_URL, "1.iso")
 """The URL to an ISO file at :data:`FILE_FIXTURE_URL`."""
 
+FILE_URL2 = urljoin(FILE_FIXTURE_URL, "2.iso")
+"""The URL to another ISO file at :data:`FILE_FIXTURE_URL`."""
+
 FILE2_FIXTURE_URL = urljoin(PULP_FIXTURES_BASE_URL, "file2/")
 """The URL to a file repository."""
 


### PR DESCRIPTION
When a RepositoryVersion has another `file.file` added with the same
`relative_path` the original one should be removed. This is shown
correctly on the RepositoryVersion `added`, `removed` fields.

This adds a test which uploads two distinct Artifacts, makes them into
File content, and then associates one, and then another with a Repo. The
second RepositoryVersion should have only 1 file.file content unit in
it.

Required PR: https://github.com/pulp/pulpcore/pull/331

https://pulp.plan.io/issues/4028
closes #4028