### PR TITLE
Use CONTENT_ORIGIN instead of CONTENT_HOST

### DIFF
--- a/.travis/install.sh
+++ b/.travis/install.sh
@@ -104,7 +104,7 @@ spec:
     username: pulp
     password: pulp
     admin_password: pulp
-  content_host: $(hostname):24816
+  content_origin: $(hostname):24816
 CRYAML
 
 # Install k3s, lightweight Kubernetes

--- a/CHANGES/5629.misc
+++ b/CHANGES/5629.misc
@@ -1,0 +1,1 @@
+Switch to using ``CONTENT_ORIGIN`` instead of ``CONTENT_HOST`` due to core changing the name.

--- a/docs/_scripts/download_after_sync.sh
+++ b/docs/_scripts/download_after_sync.sh
@@ -3,7 +3,7 @@
 # The distribution will return a url that can be used by http clients
 echo "Setting DISTRIBUTION_BASE_URL, which is used to retrieve content from the content app."
 export DISTRIBUTION_BASE_URL=$(http $BASE_ADDR$DISTRIBUTION_HREF | jq -r '.base_url')
-# If Pulp was installed without CONTENT_HOST set, it's just the path.
+# If Pulp was installed without CONTENT_ORIGIN set, it's just the path.
 # And httpie will default to localhost:80
 if [[ "${DISTRIBUTION_BASE_URL:0:1}" = "/" ]]; then
     DISTRIBUTION_BASE_URL=$CONTENT_ADDR$DISTRIBUTION_BASE_URL

--- a/docs/_scripts/download_after_upload.sh
+++ b/docs/_scripts/download_after_upload.sh
@@ -3,7 +3,7 @@
 # The distribution will return a url that can be used by http clients
 echo "Setting DISTRIBUTION_BASE_URL, which is used to retrieve content from the content app."
 export DISTRIBUTION_BASE_URL=$(http $BASE_ADDR$DISTRIBUTION_HREF | jq -r '.base_url')
-# If Pulp was installed without CONTENT_HOST set, it's just the path.
+# If Pulp was installed without CONTENT_ORIGIN set, it's just the path.
 # And httpie will default to localhost:80
 if [[ "${DISTRIBUTION_BASE_URL:0:1}" = "/" ]]; then
     DISTRIBUTION_BASE_URL=$CONTENT_ADDR$DISTRIBUTION_BASE_URL


### PR DESCRIPTION
pulpcore changed the setting name from CONTENT_HOST to CONTENT_ORIGIN.

Required PR: https://github.com/pulp/pulpcore/pull/351

https://pulp.plan.io/issues/5629
re #5629