### PR TITLE
Set CONTENT_ORIGIN settings

### DIFF
--- a/.travis/install.sh
+++ b/.travis/install.sh
@@ -105,7 +105,8 @@ spec:
     password: pulp
     admin_password: pulp
   pulp_settings:
-     content_host: $(hostname):24816
+     content_origin: http://$(hostname):24816
+
 CRYAML
 
 # Install k3s, lightweight Kubernetes

--- a/CHANGES/5629.misc
+++ b/CHANGES/5629.misc
@@ -1,0 +1,1 @@
+Set `content_origin` in Travis settings and update tests to match.

--- a/pulp_file/tests/functional/api/test_pulp_manifest.py
+++ b/pulp_file/tests/functional/api/test_pulp_manifest.py
@@ -2,7 +2,6 @@
 """Tests whether Pulp handles PULP_MANIFEST information."""
 import csv
 import unittest
-from functools import reduce
 from urllib.parse import urljoin
 
 from pulp_smash import api, config
@@ -60,14 +59,7 @@ class AccessingPublishedDataTestCase(unittest.TestCase):
 
     def download_pulp_manifest(self, distribution, unit_path):
         """Download pulp manifest."""
-        unit_url = reduce(
-            urljoin,
-            (
-                self.cfg.get_content_host_base_url(),
-                "//" + distribution["base_url"] + "/",
-                unit_path,
-            ),
-        )
+        unit_url = urljoin(distribution["base_url"] + "/", unit_path)
         return self.client.using_handler(api.safe_handler).get(unit_url)
 
 

--- a/template_config.yml
+++ b/template_config.yml
@@ -26,7 +26,7 @@ plugin_name: pulp_file
 plugin_snake: pulp_file
 plugin_snake_short: file
 pulp_settings:
-  content_host: $(hostname):24816
+  content_origin: http://$(hostname):24816
 pydocstyle: true
 pypi_username: pulp
 test: false


### PR DESCRIPTION
The Travis environment needs `content_origin` set as a setting.

This also updates the tests to expect Pulp's Distribution.base_url to
provide absolute urls.

Required PR: https://github.com/pulp/pulpcore/pull/358
Required PR: https://github.com/PulpQE/pulp-smash/pull/1227
Required PR: https://github.com/pulp/ansible-pulp/pull/185

https://pulp.plan.io/issues/5629
re #5629