### PR TITLE
Sync, Upload, Modify preserve uniqueness

### DIFF
--- a/CHANGES/3541.feature
+++ b/CHANGES/3541.feature
@@ -1,0 +1,2 @@
+Sync, Upload, and Modify now have added content with the same `relative_path` as existing content
+will remove the existing content.

--- a/pulp_file/app/models.py
+++ b/pulp_file/app/models.py
@@ -10,6 +10,7 @@ from pulpcore.plugin.models import (
     Remote,
     Repository,
 )
+from pulpcore.plugin.repo_version_utils import remove_duplicates
 
 
 log = getLogger(__name__)
@@ -28,7 +29,7 @@ class FileContent(Content):
     """
 
     TYPE = "file"
-    repo_key = ("relative_path",)
+    repo_key_fields = ("relative_path",)
 
     relative_path = models.TextField(null=False)
     digest = models.CharField(max_length=64, null=False)
@@ -47,6 +48,17 @@ class FileRepository(Repository):
 
     class Meta:
         default_related_name = "%(app_label)s_%(model_name)s"
+
+    def finalize_new_version(self, new_version):
+        """
+        Ensure no added content contains the same `relative_path` as other content.
+
+        Args:
+            new_version (pulpcore.app.models.RepositoryVersion): The incomplete RepositoryVersion to
+                finalize.
+
+        """
+        remove_duplicates(new_version)
 
 
 class FileRemote(Remote):

--- a/pulp_file/app/viewsets.py
+++ b/pulp_file/app/viewsets.py
@@ -1,8 +1,7 @@
-from gettext import gettext as _  # noqa
-
 from drf_yasg.utils import swagger_auto_schema
 from rest_framework.decorators import action
 
+from pulpcore.plugin.actions import ModifyRepositoryActionMixin
 from pulpcore.plugin.serializers import (
     AsyncOperationResponseSerializer,
     PublicationExportSerializer,
@@ -63,7 +62,7 @@ class FileContentViewSet(SingleArtifactContentUploadViewSet):
     filterset_class = FileContentFilter
 
 
-class FileRepositoryViewSet(RepositoryViewSet):
+class FileRepositoryViewSet(RepositoryViewSet, ModifyRepositoryActionMixin):
     """
     <!-- User-facing documentation, rendered as html-->
     FileRepository represents a single file repository, to which content can be synced, added,


### PR DESCRIPTION
Sync, Upload, Modify preserve uniqueness

Sync, Upload, and Modify now have added content with the same
`relative_path` as existing content will remove the existing content.

Required PR: https://github.com/pulp/pulpcore/pull/369

https://pulp.plan.io/issues/3541
re #3541