### PR TITLE
Problem: We cannot see pulpcore downgrades during plugin installs

### DIFF
--- a/.travis/check_commit.sh
+++ b/.travis/check_commit.sh
@@ -29,6 +29,7 @@ fi
 
 for sha in `git log --format=oneline --no-merges "$RANGE" | cut '-d ' -f1`
 do
+  pip install requests
   python .travis/validate_commit_message.py $sha
   VALUE=$?
 

--- a/.travis/install.sh
+++ b/.travis/install.sh
@@ -83,7 +83,7 @@ images:
         - $PULP_CERTGUARD
 VARSYAML
 fi
-ansible-playbook build.yaml
+ansible-playbook -v build.yaml
 
 cd $TRAVIS_BUILD_DIR/../pulp-operator
 # Tell pulp-perator to deploy our image

--- a/.travis/script.sh
+++ b/.travis/script.sh
@@ -109,7 +109,11 @@ set -u
 
 if [[ "$TEST" == "performance" ]]; then
   echo "--- Performance Tests ---"
-  pytest -vv -r sx --color=yes --pyargs --capture=no --durations=0 pulp_file.tests.performance || show_logs_and_return_non_zero
+  if [[ -n $PERFORMANCE_TEST ]]; then
+    pytest -vv -r sx --color=yes --pyargs --capture=no --durations=0 pulp_file.tests.performance.test_$PERFORMANCE_TEST || show_logs_and_return_non_zero
+  else
+    pytest -vv -r sx --color=yes --pyargs --capture=no --durations=0 pulp_file.tests.performance || show_logs_and_return_non_zero
+  fi
   exit
 fi
 


### PR DESCRIPTION
because the containers build.yaml output is suppressed unless
the ansible task errors.

Solution: Regenerate with plugin-template

[noissue]