### PR TITLE
Remove certguard dependency due to circular dependency

### DIFF
--- a/.travis/install.sh
+++ b/.travis/install.sh
@@ -52,12 +52,6 @@ PLUGIN=pulp_file
 
 
 # For pulpcore, and any other repo that might check out some plugin PR
-
-if [ -e $TRAVIS_BUILD_DIR/../pulp-certguard ]; then
-  PULP_CERTGUARD=./pulp-certguard
-else
-  PULP_CERTGUARD=git+https://github.com/pulp/pulp-certguard.git
-fi
 if [ -n "$TRAVIS_TAG" ]; then
   # Install the plugin only and use published PyPI packages for the rest
   cat > vars/vars.yaml << VARSYAML
@@ -68,7 +62,6 @@ images:
       tag: $TAG
       plugins:
         - ./$PLUGIN
-        - pulp-certguard
 VARSYAML
 else
   cat > vars/vars.yaml << VARSYAML
@@ -80,7 +73,6 @@ images:
       pulpcore: ./pulpcore
       plugins:
         - ./$PLUGIN
-        - $PULP_CERTGUARD
 VARSYAML
 fi
 ansible-playbook -v build.yaml

--- a/template_config.yml
+++ b/template_config.yml
@@ -1,8 +1,7 @@
 # This config represents the latest values used when running the plugin-template. Any settings that
 # were not present before running plugin-template have been added with their default values.
 
-additional_plugins:
-- pulp-certguard
+additional_plugins: []
 all: false
 black: true
 bootstrap: false
@@ -25,7 +24,7 @@ plugin_dash_short: file
 plugin_name: pulp_file
 plugin_snake: pulp_file
 plugin_snake_short: file
-pulp_settings:
+pulp_settings: null
 pydocstyle: true
 pypi_username: pulp
 test: false


### PR DESCRIPTION
We can't release pulp-certguard without pulp_file being released, and we
can't release pulp_file without pulp-cerguard being released.

[noissue]