### PR TITLE
use HTTPS for url in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setup(
     license="GPLv2+",
     author="Pulp Project Developers",
     author_email="pulp-dev@redhat.com",
-    url="http://www.pulpproject.org/",
+    url="https://pulpproject.org/",
     python_requires=">=3.6",
     install_requires=requirements,
     include_package_data=True,


### PR DESCRIPTION
also drop www, as it redirects anyways

[noissue]

(cherry picked from commit 3b8367ce407939e2c619529469f2e704148d5e4c)