### PR TITLE
Revert "Assuring downloading ISO does not go to stdout"

### DIFF
--- a/CHANGES/5775.misc
+++ b/CHANGES/5775.misc
@@ -1,1 +1,0 @@
-Assuring downloading ISO does not go to stdout during tests.

--- a/docs/_scripts/download_after_sync.sh
+++ b/docs/_scripts/download_after_sync.sh
@@ -11,4 +11,4 @@ fi
 
 # Next we download a file from the distribution
 # This will default to http://
-http -do test.iso $DISTRIBUTION_BASE_URL/test.iso
+http -d $DISTRIBUTION_BASE_URL/test.iso


### PR DESCRIPTION
This reverts commit 57a81241e778aaa874b1b3db3748e6c19edacdd5.

The change is causing the docs job to fail in Travis:

```
http: error: Cannot use --output, -o with redirected output.
```

refs #5775

Example of the failure: https://travis-ci.org/pulp/pulp_file/jobs/635423885