### PR TITLE
Revert "Downloading ISO does not go to stdout"

### DIFF
--- a/CHANGES/5775.misc
+++ b/CHANGES/5775.misc
@@ -1,1 +1,0 @@
-Assuring downloading ISO does not go to stdout during tests.

--- a/CHANGES/5967.misc
+++ b/CHANGES/5967.misc
@@ -1,0 +1,1 @@
+Revert "Downloading ISO does not go to stdout"

--- a/docs/_scripts/download_after_sync.sh
+++ b/docs/_scripts/download_after_sync.sh
@@ -11,4 +11,4 @@ fi
 
 # Next we download a file from the distribution
 # This will default to http://
-http -do test.iso $DISTRIBUTION_BASE_URL/test.iso
+http -d $DISTRIBUTION_BASE_URL/test.iso


### PR DESCRIPTION
This reverts commit 57a81241e778aaa874b1b3db3748e6c19edacdd5.

closes #5967
https://pulp.plan.io/issues/5967