### PR TITLE
Fix failing performance test

### DIFF
--- a/pulp_file/tests/performance/test_performance.py
+++ b/pulp_file/tests/performance/test_performance.py
@@ -7,7 +7,7 @@ import datetime
 import multiprocessing
 
 from collections import namedtuple
-from django.test import TestCase
+from unittest import TestCase
 
 from .pulpperf import interact
 from .pulpperf import utils


### PR DESCRIPTION
Performance tests are failing in Travis with "ModuleNotFoundError: No
module named 'django'".

https://travis-ci.org/pulp/pulp_file/jobs/638106497

[noissue]