### PR TITLE
Use a local fixture served by a separate container

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -83,6 +83,10 @@ jobs:
       env:
         - TEST=bindings
       if: tag IS present
+    - stage: daily-performance-test
+      env:
+        - TEST=performance
+      if: type = cron
     - stage: cherry-pick
       if: type = cron
       before_install: skip

--- a/CHANGES/6016.misc
+++ b/CHANGES/6016.misc
@@ -1,0 +1,1 @@
+Fixtures for performance tests are now served by an NGINX server running in a separate container

--- a/pulp_file/tests/functional/constants.py
+++ b/pulp_file/tests/functional/constants.py
@@ -67,3 +67,6 @@ FILE_LARGE_FIXTURE_URL = urljoin(PULP_FIXTURES_BASE_URL, "file-large/")
 
 FILE_LARGE_FIXTURE_MANIFEST_URL = urljoin(FILE_LARGE_FIXTURE_URL, "PULP_MANIFEST")
 """The URL to a file repository manifest."""
+
+FILE_PERFORMANCE_FIXTURE_URL = urljoin(PULP_FIXTURES_BASE_URL, "file-perf/")
+"""The URL to a file repository used for performance tests."""

--- a/pulp_file/tests/performance/pulpperf/reporting.py
+++ b/pulp_file/tests/performance/pulpperf/reporting.py
@@ -1,5 +1,4 @@
 import datetime
-import statistics
 
 DATETIME_FMT = "%Y-%m-%dT%H:%M:%S.%fZ"
 
@@ -30,69 +29,6 @@ def tasks_table(tasks, performance_task_name):
             )
         )
     return "\n".join(out)
-
-
-def tasks_min_max_table(tasks):
-    """Return overview of tasks dates min and max in a table."""
-    """
-    out = "\n%11s\t%27s\t%27s\n" % ("field", "min", "max")
-    for f in ("pulp_created", "started_at", "finished_at"):
-        sample = [datetime.datetime.strptime(t[f], DATETIME_FMT) for t in tasks]
-        out += "%11s\t%s\t%s\n" % (
-            f,
-            min(sample).strftime(DATETIME_FMT),
-            max(sample).strftime(DATETIME_FMT),
-        )
-    return out
-    """
-
-
-def data_stats(data):
-    """Return basic stats fetch from provided data."""
-    return {
-        "samples": len(data),
-        "min": min(data),
-        "max": max(data),
-        "mean": statistics.mean(data),
-        "stdev": statistics.stdev(data) if len(data) > 1 else 0.0,
-    }
-
-
-def fmt_data_stats(data):
-    """
-    Format data.
-
-    https://stackoverflow.com/questions/455612/limiting-floats-to-two-decimal-points
-    """
-    return {
-        "samples": data["samples"],
-        "min": float("%.02f" % round(data["min"], 2)),
-        "max": float("%.02f" % round(data["max"], 2)),
-        "mean": float("%.02f" % round(data["mean"], 2)),
-        "stdev": float("%.02f" % round(data["stdev"], 2)),
-    }
-
-
-def tasks_waiting_time(tasks):
-    """Analyse tasks waiting time (i.e. started_at - _created)."""
-    durations = []
-    for t in tasks:
-        diff = datetime.datetime.strptime(
-            t["started_at"], DATETIME_FMT
-        ) - datetime.datetime.strptime(t["pulp_created"], DATETIME_FMT)
-        durations.append(diff.total_seconds())
-    return fmt_data_stats(data_stats(durations))
-
-
-def tasks_service_time(tasks):
-    """Analyse tasks service time (i.e. finished_at - started_at)."""
-    durations = []
-    for t in tasks:
-        diff = datetime.datetime.strptime(
-            t["finished_at"], DATETIME_FMT
-        ) - datetime.datetime.strptime(t["started_at"], DATETIME_FMT)
-        durations.append(diff.total_seconds())
-    return fmt_data_stats(data_stats(durations))
 
 
 def print_fmt_experiment_time(label, start, end):

--- a/template_config.yml
+++ b/template_config.yml
@@ -33,7 +33,7 @@ pypi_username: pulp
 stable_branch: '0.1'
 test: false
 test_bindings: true
-test_performance: false
+test_performance: true
 travis_notifications:
   irc:
     channels:


### PR DESCRIPTION
Before this commit, fixtures for the performance tests were generated in the directory /usr/local/lib/. This caused reported permission errors when the generator was trying to write to the directory. The fixture generator was removed in this commit because it has been replaced by the existing pulp-fixtures generator https://github.com/pulp/pulp-fixtures/pull/135. Functions for printing stats which are no longer used in the performance tests were removed too.

In addition, the performance tests were enabled to run again on a daily basis.

closes #6016
https://pulp.plan.io/issues/6016