### PR TITLE
Fix the failing performance tests

### DIFF
--- a/pulp_file/tests/performance/pulpperf/interact.py
+++ b/pulp_file/tests/performance/pulpperf/interact.py
@@ -21,12 +21,12 @@ def get(url, params={}):
 def get_results(url, params={}):
     """Wrapper around requests.get with some simplification in our case."""
     out = []
-    page = 0
+    params["limit"] = 100
+    params["offset"] = 0
     while True:
         data = get(url, params)
         out += data["results"]
-        page += 1
-        params["page"] = page
+        params["offset"] += 100
         if data["next"] is None:
             break
     return out


### PR DESCRIPTION
The query parameter "page" is no longer supported by default. Therefore, the getter wrapper needs to fetch all data by leveraging a proper combination of the parameters "limit" and "offset". This should resolve the errors like "requests.exceptions.HTTPError: 400 Client Error: Bad Request for url: http://localhost:24817/pulp/api/v3/content/file/files/?repository_version=%2Fpulp%2Fapi%2Fv3%2Frepositories%2Ffile%2Ffile%2F0d4d6154-4902-42b7-be36-3ccc332ecfe6%2Fversions%2F1%2F&page=1"

[noissue]