### PR TITLE
Rename ansible-pulp to pulp_installer

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -5,7 +5,7 @@ Ansible Installer (Recommended)
 -------------------------------
 
 We recommend that you install `pulpcore` and `pulp-file` together using the `Ansible installer
-<https://github.com/pulp/ansible-pulp/blob/master/README.md>`_. The remaining steps are all
+<https://github.com/pulp/pulp_installer/blob/master/README.md>`_. The remaining steps are all
 performed by the installer and are not needed if you use it.
 
 Pip Install


### PR DESCRIPTION
[noissue]

re: #6406
Rename ansible-pulp to pulp_installer
https://pulp.plan.io/issues/6406