### PR TITLE
Renames FileFileSystemExporter to FileFilesystemExporter

### DIFF
--- a/CHANGES/6761.misc
+++ b/CHANGES/6761.misc
@@ -1,0 +1,1 @@
+Renamed FileFileSystemExporter to FileFilesystemExporter.

--- a/pulp_file/app/models.py
+++ b/pulp_file/app/models.py
@@ -4,7 +4,7 @@ from django.db import models
 
 from pulpcore.plugin.models import (
     Content,
-    FileSystemExporter,
+    FilesystemExporter,
     Publication,
     PublicationDistribution,
     Remote,
@@ -106,7 +106,7 @@ class FileDistribution(PublicationDistribution):
         default_related_name = "%(app_label)s_%(model_name)s"
 
 
-class FileFileSystemExporter(FileSystemExporter):
+class FileFilesystemExporter(FilesystemExporter):
     """
     File system exporter for 'file' content.
     """

--- a/pulp_file/app/serializers.py
+++ b/pulp_file/app/serializers.py
@@ -6,7 +6,7 @@ from pulpcore.plugin import models
 from pulpcore.plugin.serializers import (
     ContentChecksumSerializer,
     DetailRelatedField,
-    FileSystemExporterSerializer,
+    FilesystemExporterSerializer,
     PublicationDistributionSerializer,
     PublicationSerializer,
     RemoteSerializer,
@@ -17,7 +17,7 @@ from pulpcore.plugin.serializers import (
 from pulp_file.app.models import (
     FileContent,
     FileDistribution,
-    FileFileSystemExporter,
+    FileFilesystemExporter,
     FileRemote,
     FileRepository,
     FilePublication,
@@ -116,11 +116,11 @@ class FileDistributionSerializer(PublicationDistributionSerializer):
         model = FileDistribution
 
 
-class FileFileSystemExporterSerializer(FileSystemExporterSerializer):
+class FileFilesystemExporterSerializer(FilesystemExporterSerializer):
     """
     Serializer for File file system exporters.
     """
 
     class Meta:
-        fields = FileSystemExporterSerializer.Meta.fields
-        model = FileFileSystemExporter
+        fields = FilesystemExporterSerializer.Meta.fields
+        model = FileFilesystemExporter

--- a/pulp_file/app/viewsets.py
+++ b/pulp_file/app/viewsets.py
@@ -27,7 +27,7 @@ from . import tasks
 from .models import (
     FileContent,
     FileDistribution,
-    FileFileSystemExporter,
+    FileFilesystemExporter,
     FileRemote,
     FileRepository,
     FilePublication,
@@ -35,7 +35,7 @@ from .models import (
 from .serializers import (
     FileContentSerializer,
     FileDistributionSerializer,
-    FileFileSystemExporterSerializer,
+    FileFilesystemExporterSerializer,
     FileRemoteSerializer,
     FileRepositorySerializer,
     FilePublicationSerializer,
@@ -180,25 +180,26 @@ class FileDistributionViewSet(BaseDistributionViewSet):
     serializer_class = FileDistributionSerializer
 
 
-class FileFileSystemExporterViewSet(ExporterViewSet):
+class FileFilesystemExporterViewSet(ExporterViewSet):
     """
-    FileSystemExporters export content from a publication to a path on the file system.
+    FilesystemExporters export content from a publication to a path on the file system.
 
     WARNING: This feature is provided as a tech preview and may change in the future. Backwards
     compatibility is not guaranteed.
     """
 
     endpoint_name = "filesystem"
-    queryset = FileFileSystemExporter.objects.all()
-    serializer_class = FileFileSystemExporterSerializer
+    queryset = FileFilesystemExporter.objects.all()
+    serializer_class = FileFilesystemExporterSerializer
 
 
-class FileFileSystemExportViewSet(ExportViewSet):
+class FileFilesystemExportViewSet(ExportViewSet):
     """
-    FileSystemExports provide a history of previous exports.
+    FilesystemExports provide a history of previous exports.
     """
 
-    parent_viewset = FileFileSystemExporterViewSet
+    parent_viewset = FileFilesystemExporterViewSet
+    parent_lookup_kwargs = {"filesystem_exporter_pk": "filesystem_exporter__pk"}
 
     @swagger_auto_schema(
         request_body=PublicationExportSerializer,
@@ -212,8 +213,8 @@ class FileFileSystemExportViewSet(ExportViewSet):
         The ``repository`` field has to be provided.
         """
         try:
-            exporter = FileFileSystemExporter.objects.get(pk=exporter_pk)
-        except FileFileSystemExporter.DoesNotExist:
+            exporter = FileFilesystemExporter.objects.get(pk=exporter_pk)
+        except FileFilesystemExporter.DoesNotExist:
             raise Http404
 
         serializer = PublicationExportSerializer(data=request.data, context={"request": request})


### PR DESCRIPTION
Renames FileFileSystemExporter to FileFilesystemExporter
    
Required PR: https://github.com/pulp/pulpcore/pull/674
    
fixes: #6761
https://pulp.plan.io/issues/6761

