### PR TITLE
Creating a volume for /var/lib/pulp

### DIFF
--- a/.travis/install.sh
+++ b/.travis/install.sh
@@ -64,6 +64,7 @@ services:
     image: "pulp:${TAG}"
     volumes:
       - ./settings:/etc/pulp
+      - ./pulp_storage:/var/lib/pulp
 VARSYAML
 else
   cat > vars/main.yaml << VARSYAML
@@ -81,6 +82,7 @@ services:
     image: "pulp:${TAG}"
     volumes:
       - ./settings:/etc/pulp
+      - ./pulp_storage:/var/lib/pulp
 VARSYAML
 fi
 

--- a/.travis/start_container.yaml
+++ b/.travis/start_container.yaml
@@ -12,6 +12,7 @@
         mode: "0755"
       loop:
         - settings
+        - pulp_storage
         - ~/.config/pulp_smash
 
     - name: "Generate Pulp Settings"


### PR DESCRIPTION
During release CI fails due missing `/var/lib/pulp`
[noissue]