### PR TITLE
Removes the ``test_file_decriptors`` test

### DIFF
--- a/CHANGES/7454.misc
+++ b/CHANGES/7454.misc
@@ -1,0 +1,2 @@
+Removes the ``test_file_decriptors`` test which was not actually testing Pulp code and was failing
+intermittently.


### PR DESCRIPTION
The ``test_file_decriptors`` test which was not actually testing Pulp
code and was failing intermittently.

closes #7454