### PR TITLE
Add demo requirement to docs

### DIFF
--- a/CHANGES/7704.doc
+++ b/CHANGES/7704.doc
@@ -1,0 +1,1 @@
+Add demo requirement to the Contributing process.

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -6,10 +6,11 @@ To contribute to the ``pulp_file`` package follow this process:
 1. Clone the GitHub repo
 2. Make a change
 3. Add a functional test for the change
-4. Make sure all tests passed
+4. Make sure all tests pass
 5. Add a file into CHANGES folder (:ref:`changelog-update`).
-6. Commit changes to own ``pulp_file`` clone
-7. Make pull request from github page for your clone against master branch
+6. Commit changes to your own ``pulp_file`` clone
+7. `Record a demo <https://docs.pulpproject.org/pulpcore/en/master/nightly/contributing/record-a-demo.html>` (1-3 minutes).
+8. Make a pull request on the GitHub page for your clone against master branch
 
 
 .. _changelog-update:


### PR DESCRIPTION
fixes #7704

I added the requirement to record a demo from the Pulpcore docs. 

I noticed that the file structures are different in this repo, so I just followed the example here, if that is OK. 

Happy to change anything you want. 