### PR TITLE
Remove unused CONTENT_ADDR variable from docs test

### DIFF
--- a/.github/workflows/scripts/post_docs_test.sh
+++ b/.github/workflows/scripts/post_docs_test.sh
@@ -1,7 +1,6 @@
 #!/usr/bin/env sh
 
 export BASE_ADDR=http://pulp:80
-export CONTENT_ADDR=http://pulp:80
 
 cd docs/_scripts/
 bash docs_check_upload_publish.sh


### PR DESCRIPTION
We're using the distribution base url now.

[noissue]