### PR TITLE
Improve publish speed by between 2x and 20x

### DIFF
--- a/CHANGES/8508.misc
+++ b/CHANGES/8508.misc
@@ -1,0 +1,1 @@
+Substantially improved speed of publishing repositories, especially large ones.


### PR DESCRIPTION
Use a more single query rather than N small queries to iterate content
artifacts.

Using a repositoriy containing 20,000 content units, the publish time
is improved to around 1 second (opposed to ~23 seconds) if the content
is immediate, and 14 seconds (vs. the same) if content is on_demand.

Complexity (in terms of # of queries performed and not taking into account
query complexity) was reduced from 2N + 1 to either a constant or 1N
depending on whether content was synced immediate or on-demand.

Benefit is very noticeable.

closes: #8508
https://pulp.plan.io/issues/8508