### PR TITLE
Require pulpcore 3.12 due to the Distribution changes.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-pulpcore>=3.7
+pulpcore>=3.12.dev


### PR DESCRIPTION
The commit which require the bump: https://github.com/pulp/pulp_file/commit/be1c401542c8ed55192664cd9353aa6e1a52fc3b

[noissue]