### PR TITLE
Wait for tasks in test tear down

### DIFF
--- a/pulp_file/tests/functional/api/test_auto_publish.py
+++ b/pulp_file/tests/functional/api/test_auto_publish.py
@@ -48,9 +48,11 @@ class AutoPublishDistributeTestCase(unittest.TestCase):
 
     def tearDown(self):
         """Clean up."""
-        self.repo_api.delete(self.repo.pulp_href)
-        self.remote_api.delete(self.remote.pulp_href)
-        self.distributions_api.delete(self.distribution.pulp_href)
+        tasks = []
+        tasks.append(self.repo_api.delete(self.repo.pulp_href).task)
+        tasks.append(self.remote_api.delete(self.remote.pulp_href).task)
+        tasks.append(self.distributions_api.delete(self.distribution.pulp_href).task)
+        [monitor_task(task) for task in tasks]
 
     def test_01_sync(self):
         """Assert that syncing the repository triggers auto-publish and auto-distribution."""


### PR DESCRIPTION
The auto publish tests wasn't waiting properly for cleanup tasks.