### PR TITLE
Fix distribution base url on docs tests

### DIFF
--- a/.github/workflows/scripts/before_install.sh
+++ b/.github/workflows/scripts/before_install.sh
@@ -86,20 +86,6 @@ sed -i -e 's/:24817/pulp/g' generate.sh
 cd ..
 
 
-git clone --depth=1 https://github.com/pulp/pulp-cli.git
-if [ -n "$PULP_CLI_PR_NUMBER" ]; then
-  cd pulp-cli
-  git fetch origin pull/$PULP_CLI_PR_NUMBER/head:$PULP_CLI_PR_NUMBER
-  git checkout $PULP_CLI_PR_NUMBER
-  cd ..
-fi
-
-cd pulp-cli
-pip install -e .
-pulp config create --base-url http://pulp --location tests/settings.toml
-cd ..
-
-
 git clone --depth=1 https://github.com/pulp/pulpcore.git --branch master
 
 cd pulpcore
@@ -122,6 +108,18 @@ fi
 
 pip install --upgrade --force-reinstall ./pulp-smash
 
+git clone --depth=1 https://github.com/pulp/pulp-cli.git
+if [ -n "$PULP_CLI_PR_NUMBER" ]; then
+  cd pulp-cli
+  git fetch origin pull/$PULP_CLI_PR_NUMBER/head:$PULP_CLI_PR_NUMBER
+  git checkout $PULP_CLI_PR_NUMBER
+  cd ..
+fi
+
+cd pulp-cli
+pip install -e .
+pulp config create --base-url http://pulp --location tests/settings.toml
+cd ..
 
 git clone --depth=1 https://github.com/pulp/pulp-certguard.git --branch master
 if [ -n "$PULP_CERTGUARD_PR_NUMBER" ]; then

--- a/docs/_scripts/download_after_sync.sh
+++ b/docs/_scripts/download_after_sync.sh
@@ -3,4 +3,5 @@ DISTRIBUTION_BASE_URL=$(pulp file distribution show --name $DIST_NAME | jq -r '.
 
 # Next we download a file from the distribution
 echo "Downloading file from Distribution via the content app."
-http -d $DISTRIBUTION_BASE_URL/1.iso
+echo ${DISTRIBUTION_BASE_URL}1.iso
+http -d ${DISTRIBUTION_BASE_URL}1.iso

--- a/docs/_scripts/download_after_upload.sh
+++ b/docs/_scripts/download_after_upload.sh
@@ -2,5 +2,6 @@
 DISTRIBUTION_BASE_URL=$(pulp file distribution show --name $DIST_NAME | jq -r '.base_url')
 
 echo "Downloading file from Distribution via the content app."
+echo $DISTRIBUTION_BASE_URL/$ARTIFACT_RELATIVE_PATH
 # This will default to http://
 http -d $DISTRIBUTION_BASE_URL/$ARTIFACT_RELATIVE_PATH


### PR DESCRIPTION
I suspect double slashes are breaking pulp-operator test:
https://github.com/pulp/pulp-operator/runs/2601467510?check_suite_focus=true#step:11:799