### PR TITLE
Use requested version during release workflow

### DIFF
--- a/.github/workflows/scripts/install_python_client.sh
+++ b/.github/workflows/scripts/install_python_client.sh
@@ -32,7 +32,7 @@ then
   echo "pulp_file client $VERSION has already been released. Installing from PyPI."
   pip install pulp-file-client==$VERSION
   mkdir -p dist
-  tar cvf ../../pulp_file/python-client.tar ./dist
+  tar cvf python-client.tar ./dist
   exit
 fi
 

--- a/.github/workflows/scripts/release.py
+++ b/.github/workflows/scripts/release.py
@@ -275,6 +275,7 @@ if release_version != release_version_arg:
     for commit in repo.iter_commits():
         if f"Release {release_version_arg}\n" in commit.message:
             release_commit = commit
+            release_version = release_version_arg
             break
     if not release_commit:
         raise RuntimeError(


### PR DESCRIPTION
This patch also fixes how an existing python client is handled.

[noissue]