### PR TITLE
Moves the milestone check into Python script from bash

### DIFF
--- a/.ci/scripts/redmine.py
+++ b/.ci/scripts/redmine.py
@@ -12,10 +12,15 @@ from redminelib import Redmine
 
 REDMINE_API_KEY = os.environ["REDMINE_API_KEY"]
 REDMINE_QUERY_URL = sys.argv[1]
+MILESTONE_URL = sys.argv[2]
+RELEASE = sys.argv[3]
 CLOSED_CURRENTRELEASE = 11
 
 redmine = Redmine(REDMINE_QUERY_URL.split("issues")[0], key=REDMINE_API_KEY)
 query_issues = REDMINE_QUERY_URL.split("=")[-1].split(",")
+milestone_name = redmine.version.get(MILESTONE_URL.split("/")[-1].split(".")[0]).name
+if milestone_name != RELEASE:
+    raise RuntimeError(f"Milestone name, '{milestone_name}', does not match version, '{RELEASE}'.")
 
 to_update = []
 for issue in query_issues:

--- a/.ci/scripts/update_redmine.sh
+++ b/.ci/scripts/update_redmine.sh
@@ -23,12 +23,4 @@ echo "Query: $REDMINE_QUERY_URL"
 
 pip install python-redmine httpie
 
-MILESTONE=$(http $MILESTONE_URL | jq -r .version.name)
-echo "Milestone: $MILESTONE"
-
-if [[ "$MILESTONE" != "${RELEASE%.post*}" ]]; then
-  echo "Milestone $MILESTONE is not equal to Release $RELEASE"
-  exit 1
-fi
-
-python3 .ci/scripts/redmine.py $REDMINE_QUERY_URL
+python3 .ci/scripts/redmine.py $REDMINE_QUERY_URL $MILESTONE_URL $RELEASE


### PR DESCRIPTION
The http call was failing due to authentication. The Python script uses the
REDMINE_API_KEY environment variable to authenticate with the API.

[noissue]