### PR TITLE
Install pulpcore functional test requirements

### DIFF
--- a/.github/workflows/scripts/func_test_script.sh
+++ b/.github/workflows/scripts/func_test_script.sh
@@ -11,6 +11,7 @@ then
   cd ../pulpcore
   git fetch origin refs/tags/${PULPCORE_VERSION}
   git checkout FETCH_HEAD
+  pip install -r functest_requirements.txt
   cd ../pulp_file
   if [ ${PULPCORE_VERSION::3} == "3.9" ]
   then


### PR DESCRIPTION
This fixes the django not found errors when running pulpcore's tests in
the CI

[noissue]
