### PR TITLE
Bump pulpcore requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-pulpcore>=3.13.0.dev
+pulpcore>=3.15.0


### PR DESCRIPTION
pulp_file now includes ACS models which are in pulpcore 3.15

[noissue]