### PR TITLE
Runs all DB querries synchronously during a sync task.

### DIFF
--- a/CHANGES/9252.bugfix
+++ b/CHANGES/9252.bugfix
@@ -1,0 +1,1 @@
+Fixed bug where sync tasks would open a lot of DB connections.


### PR DESCRIPTION
Required PR: https://github.com/pulp/pulpcore/pull/1553

closes: #9252