### PR TITLE
Make tests more resiliant

### DIFF
--- a/pulp_file/tests/functional/api/test_acs.py
+++ b/pulp_file/tests/functional/api/test_acs.py
@@ -89,6 +89,8 @@ class AlternateContentSourceTestCase(unittest.TestCase):
 
     def test_acs_sync(self):
         """Test syncing from an ACS."""
+        delete_orphans()
+
         repo = self.repo_api.create(gen_repo())
         self.addCleanup(self.repo_api.delete, repo.pulp_href)
 


### PR DESCRIPTION
When you run the pulpcore tests and then these pulp_file tests, leftover
data from the pulpcore tests causes the first test here to unexpectedly
fail.

[noissue]