### PR TITLE
Makes pulp_file *not* a pytest plugin

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -31,8 +31,5 @@ setup(
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
     ),
-    entry_points={
-        "pulpcore.plugin": ["pulp_file = pulp_file:default_app_config"],
-        "pytest11": ["pulp_file = pulp_file.tests"],
-    },
+    entry_points={"pulpcore.plugin": ["pulp_file = pulp_file:default_app_config"]},
 )


### PR DESCRIPTION
We've consolidated all the pulp_file tests into the pulp_file repo, so
there is no reason to have pulp_file provide fixtures externally
anymore.

[noissue]