### PR TITLE
Adds "basic_manifest_path" fixture

### DIFF
--- a/pulp_file/tests/functional/api/from_pulpcore/test_proxy.py
+++ b/pulp_file/tests/functional/api/from_pulpcore/test_proxy.py
@@ -26,12 +26,13 @@ def test_sync_http_through_http_proxy(
     file_repo_api_client,
     file_content_api_client,
     http_proxy,
+    basic_manifest_path,
 ):
     """
     Test syncing http through a http proxy.
     """
     remote_on_demand = file_fixture_gen_remote(
-        fixture_name="basic", policy="on_demand", proxy_url=http_proxy.proxy_url
+        manifest_path=basic_manifest_path, policy="on_demand", proxy_url=http_proxy.proxy_url
     )
 
     _run_basic_sync_and_assert(
@@ -46,12 +47,13 @@ def test_sync_https_through_http_proxy(
     file_repo_api_client,
     file_content_api_client,
     http_proxy,
+    basic_manifest_path,
 ):
     """
     Test syncing https through a http proxy.
     """
     remote_on_demand = file_fixture_gen_remote_ssl(
-        fixture_name="basic", policy="on_demand", proxy_url=http_proxy.proxy_url
+        manifest_path=basic_manifest_path, policy="on_demand", proxy_url=http_proxy.proxy_url
     )
 
     _run_basic_sync_and_assert(
@@ -66,12 +68,13 @@ def test_sync_https_through_http_proxy_with_auth(
     file_repo_api_client,
     file_content_api_client,
     http_proxy_with_auth,
+    basic_manifest_path,
 ):
     """
     Test syncing https through a http proxy that requires auth.
     """
     remote_on_demand = file_fixture_gen_remote_ssl(
-        fixture_name="basic",
+        manifest_path=basic_manifest_path,
         policy="on_demand",
         tls_validation="true",
         proxy_url=http_proxy_with_auth.proxy_url,
@@ -91,12 +94,13 @@ def test_sync_https_through_http_proxy_with_auth_but_auth_not_configured(
     file_repo_api_client,
     file_content_api_client,
     http_proxy_with_auth,
+    basic_manifest_path,
 ):
     """
     Test syncing https through a http proxy that requires auth, but auth is not configured.
     """
     remote_on_demand = file_fixture_gen_remote_ssl(
-        fixture_name="basic",
+        manifest_path=basic_manifest_path,
         policy="on_demand",
         tls_validation="true",
         proxy_url=http_proxy_with_auth.proxy_url,
@@ -117,12 +121,13 @@ def test_sync_http_through_https_proxy(
     file_repo_api_client,
     file_content_api_client,
     https_proxy,
+    basic_manifest_path,
 ):
     """
     Test syncing http through an https proxy.
     """
     remote_on_demand = file_fixture_gen_remote(
-        fixture_name="basic",
+        manifest_path=basic_manifest_path,
         policy="on_demand",
         proxy_url=https_proxy.proxy_url,
         tls_validation="false",  # We instead should have a `proxy_insecure` option

--- a/pulp_file/tests/functional/api/from_pulpcore/test_sync.py
+++ b/pulp_file/tests/functional/api/from_pulpcore/test_sync.py
@@ -33,11 +33,14 @@ def test_http_sync_no_ssl(
     file_repo,
     file_repo_api_client,
     file_content_api_client,
+    basic_manifest_path,
 ):
     """
     Test file on_demand sync with plain http://
     """
-    remote_on_demand = file_fixture_gen_remote(fixture_name="basic", policy="on_demand")
+    remote_on_demand = file_fixture_gen_remote(
+        manifest_path=basic_manifest_path, policy="on_demand"
+    )
 
     _run_basic_sync_and_assert(
         remote_on_demand, file_repo, file_repo_api_client, file_content_api_client
@@ -50,12 +53,13 @@ def test_http_sync_ssl_tls_validation_off(
     file_repo,
     file_repo_api_client,
     file_content_api_client,
+    basic_manifest_path,
 ):
     """
     Test file on_demand sync with https:// serving from an untrusted certificate.
     """
     remote_on_demand = file_fixture_gen_remote_ssl(
-        fixture_name="basic", policy="on_demand", tls_validation="false"
+        manifest_path=basic_manifest_path, policy="on_demand", tls_validation="false"
     )
 
     _run_basic_sync_and_assert(
@@ -69,12 +73,13 @@ def test_http_sync_ssl_tls_validation_on(
     file_repo,
     file_repo_api_client,
     file_content_api_client,
+    basic_manifest_path,
 ):
     """
     Test file on_demand sync with https:// and a client connection configured to trust it.
     """
     remote_on_demand = file_fixture_gen_remote_ssl(
-        fixture_name="basic", policy="on_demand", tls_validation="true"
+        manifest_path=basic_manifest_path, policy="on_demand", tls_validation="true"
     )
 
     _run_basic_sync_and_assert(
@@ -88,12 +93,15 @@ def test_http_sync_ssl_tls_validation_defaults_to_on(
     file_repo,
     file_repo_api_client,
     file_content_api_client,
+    basic_manifest_path,
 ):
     """
     Test file on_demand sync with https:// and that tls validation is on by default.
     """
 
-    remote_on_demand = file_fixture_gen_remote_ssl(fixture_name="basic", policy="on_demand")
+    remote_on_demand = file_fixture_gen_remote_ssl(
+        manifest_path=basic_manifest_path, policy="on_demand"
+    )
 
     _run_basic_sync_and_assert(
         remote_on_demand, file_repo, file_repo_api_client, file_content_api_client
@@ -106,12 +114,13 @@ def test_http_sync_ssl_with_client_cert_req(
     file_repo,
     file_repo_api_client,
     file_content_api_client,
+    basic_manifest_path,
 ):
     """
     Test file on_demand sync with https:// and mutual authentication between client and server.
     """
     remote_on_demand = file_fixture_gen_remote_client_cert_req(
-        fixture_name="basic", policy="on_demand"
+        manifest_path=basic_manifest_path, policy="on_demand"
     )
 
     _run_basic_sync_and_assert(
@@ -125,11 +134,14 @@ def test_ondemand_to_immediate_sync(
     file_repo,
     file_repo_api_client,
     file_content_api_client,
+    basic_manifest_path,
 ):
     """
     Test file on_demand sync does not bring in Artifacts, but a later sync with "immediate" will.
     """
-    remote_on_demand = file_fixture_gen_remote_ssl(fixture_name="basic", policy="on_demand")
+    remote_on_demand = file_fixture_gen_remote_ssl(
+        manifest_path=basic_manifest_path, policy="on_demand"
+    )
 
     _run_basic_sync_and_assert(
         remote_on_demand,
@@ -138,7 +150,9 @@ def test_ondemand_to_immediate_sync(
         file_content_api_client,
     )
 
-    remote_immediate = file_fixture_gen_remote_ssl(fixture_name="basic", policy="immediate")
+    remote_immediate = file_fixture_gen_remote_ssl(
+        manifest_path=basic_manifest_path, policy="immediate"
+    )
 
     _run_basic_sync_and_assert(
         remote_immediate,
@@ -158,12 +172,13 @@ def test_header_for_sync(
     file_repo_api_client,
     file_content_api_client,
     gen_object_with_cleanup,
+    basic_manifest_path,
 ):
     """
     Test file sync will correctly submit header data during download when configured.
     """
     requests_record = file_fixture_server_ssl.requests_record
-    url = file_fixture_server_ssl.make_url("/PULP_MANIFEST")
+    url = file_fixture_server_ssl.make_url("/basic/PULP_MANIFEST")
 
     header_name = "X-SOME-HEADER"
     header_value = str(uuid.uuid4())
@@ -183,6 +198,6 @@ def test_header_for_sync(
     )
 
     assert len(requests_record) == 1
-    assert requests_record[0].path == "/PULP_MANIFEST"
+    assert requests_record[0].path == "/basic/PULP_MANIFEST"
     assert header_name in requests_record[0].headers
     assert header_value == requests_record[0].headers[header_name]

--- a/pulp_file/tests/functional/conftest.py
+++ b/pulp_file/tests/functional/conftest.py
@@ -83,11 +83,17 @@ def file_remote_api_client(file_client):
 
 @pytest.fixture()
 def file_fixtures_root(tmpdir):
-    file1 = generate_iso(tmpdir.join("1.iso"))
-    file2 = generate_iso(tmpdir.join("2.iso"))
-    file3 = generate_iso(tmpdir.join("3.iso"))
-    generate_manifest(tmpdir.join("PULP_MANIFEST"), [file1, file2, file3])
     return Path(tmpdir)
+
+
+@pytest.fixture()
+def basic_manifest_path(file_fixtures_root):
+    file_fixtures_root.joinpath("basic").mkdir()
+    file1 = generate_iso(file_fixtures_root.joinpath("basic/1.iso"))
+    file2 = generate_iso(file_fixtures_root.joinpath("basic/2.iso"))
+    file3 = generate_iso(file_fixtures_root.joinpath("basic/3.iso"))
+    generate_manifest(file_fixtures_root.joinpath("basic/PULP_MANIFEST"), [file1, file2, file3])
+    return "/basic/PULP_MANIFEST"
 
 
 @pytest.fixture
@@ -109,8 +115,8 @@ def file_fixture_server(file_fixtures_root, gen_fixture_server):
 
 @pytest.fixture
 def file_fixture_gen_remote(file_fixture_server, file_remote_api_client, gen_object_with_cleanup):
-    def _file_fixture_gen_remote(*, fixture_name, policy, **kwargs):
-        url = file_fixture_server.make_url(f"/PULP_MANIFEST")
+    def _file_fixture_gen_remote(*, manifest_path, policy, **kwargs):
+        url = file_fixture_server.make_url(manifest_path)
         kwargs.update({"url": str(url), "policy": policy, "name": str(uuid.uuid4())})
         return gen_object_with_cleanup(file_remote_api_client, kwargs)
 
@@ -124,8 +130,8 @@ def file_fixture_gen_remote_ssl(
     tls_certificate_authority_cert,
     gen_object_with_cleanup,
 ):
-    def _file_fixture_gen_remote_ssl(*, fixture_name, policy, **kwargs):
-        url = file_fixture_server_ssl.make_url(f"/PULP_MANIFEST")
+    def _file_fixture_gen_remote_ssl(*, manifest_path, policy, **kwargs):
+        url = file_fixture_server_ssl.make_url(manifest_path)
         kwargs.update(
             {
                 "url": str(url),
@@ -148,8 +154,8 @@ def file_fixture_gen_remote_client_cert_req(
     client_tls_certificate_key_pem,
     gen_object_with_cleanup,
 ):
-    def _file_fixture_gen_remote_client_cert_req(*, fixture_name, policy, **kwargs):
-        url = file_fixture_server_ssl_client_cert_req.make_url(f"/PULP_MANIFEST")
+    def _file_fixture_gen_remote_client_cert_req(*, manifest_path, policy, **kwargs):
+        url = file_fixture_server_ssl_client_cert_req.make_url(manifest_path)
         kwargs.update(
             {
                 "url": str(url),

--- a/pulp_file/tests/functional/utils.py
+++ b/pulp_file/tests/functional/utils.py
@@ -282,7 +282,7 @@ def generate_iso(name, size=1024):
         fout.write(contents)
         fout.flush()
     digest = hashlib.sha256(contents).hexdigest()
-    return {"name": name.basename, "size": size, "digest": digest}
+    return {"name": name.name, "size": size, "digest": digest}
 
 
 def generate_manifest(name, file_list):


### PR DESCRIPTION
This fixture replaces the "file_fixture_basic". The new fixture can be used by
tests directly. This introduces a new pattern for writing file fixtures that will
allow each test to specify which specific randomly generated fixture it should
use. In the future we will add fixtures that represent other file fixtures that
are present in fixtures.pulpproject.org.


[noissue]