### PR TITLE
Skip a failing test in nightly

### DIFF
--- a/pulp_file/tests/functional/api/from_pulpcore/test_remove_plugin.py
+++ b/pulp_file/tests/functional/api/from_pulpcore/test_remove_plugin.py
@@ -3,9 +3,9 @@ import pytest
 from pulp_smash.pulp3.utils import gen_repo
 
 
-# Marking test trylast to ensure other tests run even if this fails.
+@pytest.mark.skip(reason="needs to actually pip uninstall and it doesn't do that yet.")
 @pytest.mark.nightly
-@pytest.mark.trylast
+@pytest.mark.trylast  # Marking test trylast to ensure other tests run even if this fails.
 def test_remove_plugin(
     cli_client,
     delete_orphans_pre,


### PR DESCRIPTION
The test fails because it needs to actually pip uninstall during the
test. By not doing so, migrations are leftover and the restart script
hangs waiting for them to apply. The suggestion on Matrix was to skip
for now.

[noissue]