### PR TITLE
Improved error message when parsing invalid manifest file

### DIFF
--- a/CHANGES/605.bugfix
+++ b/CHANGES/605.bugfix
@@ -1,0 +1,1 @@
+Improved the error message shown when a user specifies an invalid path to the manifest file, or the manifest file is in the incorrect format.

--- a/pulp_file/manifest.py
+++ b/pulp_file/manifest.py
@@ -52,9 +52,12 @@ class Entry:
         part = [s.strip() for s in line.content.split(",")]
         if len(part) != 3:
             raise ValueError(
-                _("Error: manifest line:{n}: " "must be: <relative_path>,<digest>,<size>").format(
-                    n=line.number
-                )
+                _(
+                    "Error: Parsing of the manifest file failed on line:{n}.\n"
+                    "Please make sure the remote URL is pointing to a valid manifest file.\n"
+                    "The manifest file should be "
+                    "composed of lines in the following format: <relative_path>,<digest>,<size>."
+                ).format(n=line.number)
             )
         return Entry(relative_path=part[0], digest=part[1], size=int(part[2]))
 


### PR DESCRIPTION
The issue was originally opened because Pulp attempted to create a
directory even after raising the error message, which is no longer the
case for quite some time. This commit improves the error message to
alert the user in a more understandable way.

closes #605