### PR TITLE
The relative_path field of PULP_MANIFEST can now contain commas

### DIFF
--- a/CHANGES/630.bugfix
+++ b/CHANGES/630.bugfix
@@ -1,0 +1,1 @@
+The relative_path field of PULP_MANIFEST can now contain commas, since they are valid filename characters in both Linux and Windows filesystems.

--- a/pulp_file/tests/functional/api/test_sync.py
+++ b/pulp_file/tests/functional/api/test_sync.py
@@ -108,3 +108,19 @@ def test_duplicate_file_sync(
     assert get_content_summary(file_repo.to_dict()) == {"file.file": 3}
     assert get_added_content_summary(file_repo.to_dict()) == {"file.file": 3}
     assert file_repo.latest_version_href.endswith("/2/")
+
+
+@pytest.mark.parallel
+def test_filepath_includes_commas(
+    file_repo, file_fixture_gen_remote, manifest_path_with_commas, file_repo_api_client
+):
+    """Sync a repository using a manifest file with a file whose relative_path includes commas"""
+    remote = file_fixture_gen_remote(manifest_path=manifest_path_with_commas, policy="on_demand")
+
+    body = RepositorySyncURL(remote=remote.pulp_href)
+    monitor_task(file_repo_api_client.sync(file_repo.pulp_href, body).task)
+    file_repo = file_repo_api_client.read(file_repo.pulp_href)
+
+    assert get_content_summary(file_repo.to_dict()) == {"file.file": 3}
+    assert get_added_content_summary(file_repo.to_dict()) == {"file.file": 3}
+    assert file_repo.latest_version_href.endswith("/1/")

--- a/pulp_file/tests/functional/conftest.py
+++ b/pulp_file/tests/functional/conftest.py
@@ -153,6 +153,20 @@ def large_manifest_path(file_fixtures_root):
 
 
 @pytest.fixture
+def manifest_path_with_commas(file_fixtures_root):
+    file_fixtures_root.joinpath("comma_test").mkdir()
+    file_fixtures_root.joinpath("comma_test/comma,folder").mkdir()
+    file_fixtures_root.joinpath("comma_test/basic_folder").mkdir()
+    file1 = generate_iso(file_fixtures_root.joinpath("comma_test/comma,folder/,comma,,file,.iso"))
+    file2 = generate_iso(file_fixtures_root.joinpath("comma_test/comma,folder/basic_file.iso"))
+    file3 = generate_iso(file_fixtures_root.joinpath("comma_test/basic_folder/comma,file.iso"))
+    generate_manifest(
+        file_fixtures_root.joinpath("comma_test/PULP_MANIFEST"), [file1, file2, file3]
+    )
+    return "/comma_test/PULP_MANIFEST"
+
+
+@pytest.fixture
 def invalid_manifest_path(file_fixtures_root, basic_manifest_path):
     file_path_to_corrupt = file_fixtures_root / Path("basic/1.iso")
     with open(file_path_to_corrupt, "w") as f:


### PR DESCRIPTION
Commas are a valid filename characters in both Linux and Windows
file systems, but the previous way of generating manifest file
did not	allow them. This commit	fixes this issue, and introduces
a test for this	very specific edge-case. The test is split into
all three possible sub-cases: comma in filename, comma in folder
name, comma(s) in both.

closes pulp#630