### PR TITLE
Allow uploading existing FileContent units

### DIFF
--- a/CHANGES/774.feature
+++ b/CHANGES/774.feature
@@ -1,0 +1,1 @@
+The upload feature was changed to accept already existing file content. This allows multiple users to own identical files.

--- a/pulp_file/app/serializers.py
+++ b/pulp_file/app/serializers.py
@@ -35,21 +35,13 @@ class FileContentSerializer(SingleArtifactContentUploadSerializer, ContentChecks
 
         data["digest"] = data["artifact"].sha256
 
-        content = FileContent.objects.filter(
-            digest=data["digest"], relative_path=data["relative_path"]
-        )
-
-        if content.exists():
-            content.get().touch()
-
-            raise serializers.ValidationError(
-                _(
-                    "There is already a file content with relative path '{path}' and digest "
-                    "'{digest}'."
-                ).format(path=data["relative_path"], digest=data["digest"])
-            )
-
         return data
+
+    def retrieve(self, validated_data):
+        content = FileContent.objects.filter(
+            digest=validated_data["digest"], relative_path=validated_data["relative_path"]
+        )
+        return content.first()
 
     class Meta:
         fields = (

--- a/pulp_file/tests/unit/test_serializers.py
+++ b/pulp_file/tests/unit/test_serializers.py
@@ -45,11 +45,11 @@ class TestFileContentSerializer(TestCase):
         self.assertFalse(serializer.is_valid())
 
     def test_duplicate_data(self):
-        """Test that the FileContentSerializer does not accept data."""
+        """Test that the FileContentSerializer accepts duplicate valid data."""
         FileContent.objects.create(relative_path="foo", digest=self.artifact.sha256)
         data = {
             "artifact": f"{V3_API_ROOT}artifacts/{self.artifact.pk}/",
             "relative_path": "foo",
         }
         serializer = FileContentSerializer(data=data)
-        self.assertFalse(serializer.is_valid())
+        self.assertTrue(serializer.is_valid())

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-pulpcore>=3.21.0.dev,<3.25
+pulpcore>=3.22.0.dev,<3.25


### PR DESCRIPTION
Attemting to upload a FileContent unit already present inside a
different repository no longer results in an exception being raised,
the existing unit is re-used instead (without notifying the user).

An exception is still raised if either a user attempts to upload the
unit into a repository inside which it already exists, or the admin
attempts to upload an existing unit without specifying a repository.

closes #774