### PR TITLE
Added test for listing master model remotes

### DIFF
--- a/pulp_file/tests/functional/api/test_generic_list.py
+++ b/pulp_file/tests/functional/api/test_generic_list.py
@@ -39,3 +39,22 @@ def test_read_all_content_guards_generic(
     assert response.count != 0
     for content_guard in response.results:
         assert content_guard.name is not None
+
+
+@pytest.mark.parallel
+def test_read_all_master_model_remotes_generic(
+    remotes_api_client, gen_object_with_cleanup, file_remote_api_client
+):
+    remote_data = {"name": str(uuid.uuid4()), "url": "http://example.com"}
+    remote1 = gen_object_with_cleanup(file_remote_api_client, remote_data)
+    remote_data = {"name": str(uuid.uuid4()), "url": "http://example.org"}
+    remote2 = gen_object_with_cleanup(file_remote_api_client, remote_data)
+
+    response = remotes_api_client.list()
+    assert response.count != 0
+
+    hrefs = []
+    for remote in response.results:
+        hrefs.append(remote.pulp_href)
+    assert remote1.pulp_href in hrefs
+    assert remote2.pulp_href in hrefs

--- a/pulp_file/tests/functional/conftest.py
+++ b/pulp_file/tests/functional/conftest.py
@@ -32,10 +32,7 @@ _logger = logging.getLogger(__name__)
 def pytest_check_for_leftover_pulp_objects(config):
     file_client = gen_file_client()
 
-    types_to_check = [
-        FileFileAlternateContentSource(file_client),
-        RemotesFileApi(file_client),
-    ]
+    types_to_check = [FileFileAlternateContentSource(file_client)]
     for type_to_check in types_to_check:
         if type_to_check.list().count > 0:
             raise Exception(f"This test left over a {type_to_check}.")


### PR DESCRIPTION
A new feature has been added to pulpcore, which allows users to list
all master model remotes at /pulp/api/v3/remotes/. A test case
covering this feature has been added.

closes #800

Required-PR: pulp/pulpcore#3150