### PR TITLE
Refactors orphans delete and cleanup tests

### DIFF
--- a/CHANGES/814.misc
+++ b/CHANGES/814.misc
@@ -1,0 +1,1 @@
+Refactored orphans delete and cleanup tests to use pytest fixtures.


### PR DESCRIPTION
These tests now use pytest fixtures.

Required PR: https://github.com/pulp/pulpcore/pull/3250

fixes: #816