### PR TITLE
Improved the content-disposition assertions

### DIFF
--- a/pulp_file/tests/functional/api/test_download_policies.py
+++ b/pulp_file/tests/functional/api/test_download_policies.py
@@ -1,6 +1,7 @@
 """Tests for Pulp`s download policies."""
 from aiohttp.client_exceptions import ClientResponseError
 import hashlib
+import os
 import pytest
 import uuid
 from urllib.parse import urljoin
@@ -120,7 +121,7 @@ def test_download_policy(
     if download_policy == "immediate" and settings.DEFAULT_FILE_STORAGE in OBJECT_STORAGES:
         content_disposition = downloaded_file.response_obj.headers.get("Content-Disposition")
         assert content_disposition is not None
-        filename = content_unit[0]
+        filename = os.path.basename(content_unit[0])
         assert f"attachment;filename={filename}" == content_disposition
 
     # Assert proper download with range requests smaller than one chunk of downloader

--- a/pulp_file/tests/functional/conftest.py
+++ b/pulp_file/tests/functional/conftest.py
@@ -160,19 +160,17 @@ def large_manifest_path(file_fixtures_root):
 def range_header_manifest_path(file_fixtures_root):
     """A path to a File repository manifest that contains 8 unique files each 4mb in size."""
     one_megabyte = 1048576
-    file_fixtures_root.joinpath("range").mkdir()
-    file1 = generate_iso(file_fixtures_root.joinpath("range/1.iso"), 4 * one_megabyte)
-    file2 = generate_iso(file_fixtures_root.joinpath("range/2.iso"), 4 * one_megabyte)
-    file3 = generate_iso(file_fixtures_root.joinpath("range/3.iso"), 4 * one_megabyte)
-    file4 = generate_iso(file_fixtures_root.joinpath("range/4.iso"), 4 * one_megabyte)
-    file5 = generate_iso(file_fixtures_root.joinpath("range/5.iso"), 4 * one_megabyte)
-    file6 = generate_iso(file_fixtures_root.joinpath("range/6.iso"), 4 * one_megabyte)
-    file7 = generate_iso(file_fixtures_root.joinpath("range/7.iso"), 4 * one_megabyte)
-    file8 = generate_iso(file_fixtures_root.joinpath("range/8.iso"), 4 * one_megabyte)
+    file_fixtures_root.joinpath("range/foo").mkdir(parents=True)
+    files = [
+        generate_iso(
+            file_fixtures_root.joinpath(f"range/foo/{i}.iso"), 4 * one_megabyte, f"foo/{i}.iso"
+        )
+        for i in range(8)
+    ]
 
     generate_manifest(
         file_fixtures_root.joinpath("range/PULP_MANIFEST"),
-        [file1, file2, file3, file4, file5, file6, file7, file8],
+        files,
     )
     return "/range/PULP_MANIFEST"
 

--- a/pulp_file/tests/functional/utils.py
+++ b/pulp_file/tests/functional/utils.py
@@ -269,14 +269,18 @@ def parse_date_from_string(s, parse_format="%Y-%m-%dT%H:%M:%S.%fZ"):
     return datetime.strptime(s, parse_format)
 
 
-def generate_iso(name, size=1024):
+def generate_iso(full_path, size=1024, relative_path=None):
     """Generate a random file."""
-    with open(name, "wb") as fout:
+    with open(full_path, "wb") as fout:
         contents = os.urandom(size)
         fout.write(contents)
         fout.flush()
     digest = hashlib.sha256(contents).hexdigest()
-    return {"name": name.name, "size": size, "digest": digest}
+    if relative_path:
+        name = relative_path
+    else:
+        name = full_path.name
+    return {"name": name, "size": size, "digest": digest}
 
 
 def generate_manifest(name, file_list):


### PR DESCRIPTION
This patch adds relative paths to the manifest used for download policy tests.

Required PR: https://github.com/pulp/pulpcore/pull/3348

[noissue]