### PR TITLE
Remove client bindings from functest_requirements

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -18,6 +18,4 @@ values =
 
 [bumpversion:file:./setup.py]
 
-[bumpversion:file:./functest_requirements.txt]
-
 [bumpversion:file:./docs/conf.py]

--- a/functest_requirements.txt
+++ b/functest_requirements.txt
@@ -2,7 +2,4 @@ aiofiles
 aiohttp
 beautifulsoup4
 pulp-smash @ git+https://github.com/pulp/pulp-smash.git
-pulpcore-client
-pulp-certguard-client
-pulp-file-client==1.14.0.dev
 pytest


### PR DESCRIPTION
They should be there for consistency, but this breaks with older branches.

[noissue]