### PR TITLE
Add a final release note

### DIFF
--- a/CHANGES/+final_release_note.removal
+++ b/CHANGES/+final_release_note.removal
@@ -1,0 +1,3 @@
+This is the last release of ``pulp_file`` as an independent package.
+Its bits have been moved to ``pulpcore>=3.40.0`` and this is essentially an empty package.
+You can safely remove it.


### PR DESCRIPTION
This tells the reader of release notes that this package can safely be removed after upgrading pulpcore.

[noissue]